### PR TITLE
chore: group Renovate updates and run monthly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "schedule:monthly"
+  ],
+  "timezone": "UTC",
+  "packageRules": [
+    {
+      "matchPackageNames": ["io.ktor:*"],
+      "groupName": "Ktor"
+    },
+    {
+      "matchPackageNames": ["org.jetbrains.kotlinx:kotlinx-coroutines-*"],
+      "groupName": "Kotlinx Coroutines"
+    },
+    {
+      "matchPackageNames": ["org.jetbrains.kotlinx:kotlinx-serialization-*"],
+      "groupName": "Kotlinx Serialization"
+    },
+    {
+      "matchPackageNames": [
+        "org.jetbrains.kotlin:*",
+        "org.jetbrains.kotlin.multiplatform",
+        "org.jetbrains.kotlin.plugin.serialization"
+      ],
+      "groupName": "Kotlin"
+    },
+    {
+      "matchPackageNames": [
+        "com.android.library",
+        "com.android.application",
+        "com.android.tools.build:gradle"
+      ],
+      "groupName": "Android Gradle Plugin"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
## Summary
Move `renovate.json` into `.github/` and extend it with a monthly schedule (`schedule:monthly`) plus package rules that group related dependencies — so updates arrive as one PR per ecosystem instead of one PR per artifact.

### Groups
- **Ktor** — `io.ktor:*`
- **Kotlinx Coroutines** — `org.jetbrains.kotlinx:kotlinx-coroutines-*`
- **Kotlinx Serialization** — `org.jetbrains.kotlinx:kotlinx-serialization-*`
- **Kotlin** — `org.jetbrains.kotlin:*` and the `kotlin.multiplatform` / `kotlin.plugin.serialization` plugins
- **Android Gradle Plugin** — `com.android.library`, `com.android.application`, `com.android.tools.build:gradle`
- **GitHub Actions** — everything handled by the `github-actions` manager

## Test plan
- [ ] Renovate picks up `.github/renovate.json` on the next scheduled run (first day of the month).
- [ ] Grouped PRs appear per ecosystem instead of one PR per artifact.