### PR TITLE
Migrate Android target to com.android.kotlin.multiplatform.library (AGP 9)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.android.kotlin.multiplatform.library) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlinx.serialization) apply false
     alias(libs.plugins.dokka) apply false

--- a/deepseek-kotlin/build.gradle.kts
+++ b/deepseek-kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    alias(libs.plugins.android.library)
+    alias(libs.plugins.android.kotlin.multiplatform.library)
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.dokka)
@@ -24,8 +24,10 @@ kotlin {
         }
     }
 
-    androidTarget {
-        publishLibraryVariants("release")
+    android {
+        namespace = "org.oremif.deepseek"
+        compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
         }
@@ -35,21 +37,20 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    macosX64()
     macosArm64()
     linuxX64()
     linuxArm64()
     mingwX64()
 
     wasmJs {
-        nodejs() {
+        nodejs {
             testTask {
                 useMocha {
                     timeout = "30s"
                 }
             }
         }
-        browser() {
+        browser {
             testTask {
                 useMocha {
                     timeout = "30s"
@@ -120,19 +121,6 @@ kotlin {
         }
     }
 }
-
-android {
-    namespace = "org.oremif.deepseek"
-    defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-}
-
 
 dokka {
     moduleName.set("DeepSeek Kotlin SDK")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 
 [plugins]
-android-library = { id = "com.android.library", version.ref = "agp" }
+android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }


### PR DESCRIPTION
## Summary
- AGP 9 no longer allows `com.android.library` together with `org.jetbrains.kotlin.multiplatform` in the same module (after the last renovate bump to AGP 9.1.0 the build failed with `Cannot add extension with name 'kotlin'`).
- Switch the library module to the new KMP-aware plugin `com.android.kotlin.multiplatform.library` per the official migration guide.
- Move `namespace` / `compileSdk` / `minSdk` / `jvmTarget` from the top-level `android {}` block into `kotlin { android {} }`, drop the old `androidTarget { publishLibraryVariants(...) }` (new plugin is single-variant), and drop the deprecated `macosX64` target.

## Test plan
- [x] `./gradlew :deepseek-kotlin:build --no-build-cache --rerun-tasks` passes (JVM, Android, iOS, macOS arm64, Linux x64/arm64, mingwX64, wasmJs)
- [x] Running tests pass on host (jvmTest, iosSimulatorArm64Test, macosArm64Test, wasmJsBrowserTest, wasmJsNodeTest); platform-mismatched targets are correctly SKIPPED