### PR TITLE
preserve default Ktor plugins in httpClient { } builder

### DIFF
--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
@@ -222,29 +222,47 @@ public abstract class DeepSeekClientBase(
         }
 
         /**
-         * Configures the underlying HTTP client with custom settings.
+         * Applies additional configuration on top of the default HTTP client.
          *
-         * Use this method for advanced customization of the HTTP client.
+         * The [block] is merged with the existing configuration via [HttpClient.config], so the
+         * defaults installed by the builder (Auth, ContentNegotiation, base URL via
+         * `defaultRequest`, HttpRequestRetry, HttpTimeout, Logging — plus SSE for
+         * [DeepSeekClientStream]) are preserved. Calling this method multiple times layers each
+         * [block] on top of the previous state.
          *
-         * Example:
+         * Use [httpClient] with an [HttpClient] argument if you want to replace the underlying
+         * client entirely instead of extending it.
+         *
+         * Example — override the request timeout while keeping all other defaults:
          * ```kotlin
          * val client = DeepSeekClient("token") {
          *     httpClient {
          *         install(HttpTimeout) {
-         *             requestTimeoutMillis = 60000
+         *             requestTimeoutMillis = 60_000
          *         }
          *     }
          * }
          * ```
          *
-         * @param block Configuration block for the HTTP client
+         * @param block Additional configuration to merge on top of the default HTTP client
          * @return This builder for chaining
          */
         public fun httpClient(block: HttpClientConfig<*>.() -> Unit): Builder {
-            client = HttpClient { block(this) }
+            client = client.config(block)
             return this
         }
 
+        /**
+         * Replaces the underlying HTTP client entirely with the provided [client].
+         *
+         * Unlike the [httpClient] overload that takes a configuration block, this overload does
+         * **not** preserve the builder defaults — the caller is responsible for installing Auth,
+         * ContentNegotiation, the base URL in `defaultRequest`, retries, timeouts, logging, and
+         * (for streaming) SSE.
+         *
+         * @param client Fully configured HTTP client to use
+         * @return This builder for chaining
+         */
         public fun httpClient(client: HttpClient): Builder {
             this.client = client
             return this

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/client/DeepSeekClientBuilderTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/client/DeepSeekClientBuilderTests.kt
@@ -1,0 +1,73 @@
+package org.oremif.deepseek.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.pluginOrNull
+import io.ktor.client.plugins.sse.SSE
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class DeepSeekClientBuilderTests {
+
+    @Test
+    fun `httpClient block preserves default plugins on DeepSeekClient`() {
+        DeepSeekClient("test-token") {
+            httpClient { /* additive configuration — intentionally empty */ }
+        }.use { client ->
+            val http = client.client
+            assertNotNull(http.pluginOrNull(Auth), "Auth must survive httpClient { }")
+            assertNotNull(
+                http.pluginOrNull(ContentNegotiation),
+                "ContentNegotiation must survive httpClient { }"
+            )
+            assertNotNull(
+                http.pluginOrNull(HttpRequestRetry),
+                "HttpRequestRetry must survive httpClient { }"
+            )
+            assertNotNull(http.pluginOrNull(HttpTimeout), "HttpTimeout must survive httpClient { }")
+            assertNotNull(http.pluginOrNull(Logging), "Logging must survive httpClient { }")
+        }
+    }
+
+    @Test
+    fun `httpClient block preserves SSE and base plugins on DeepSeekClientStream`() {
+        DeepSeekClientStream("test-token") {
+            httpClient { /* additive configuration — intentionally empty */ }
+        }.use { client ->
+            val http = client.client
+            assertNotNull(http.pluginOrNull(SSE), "SSE must survive httpClient { } on stream client")
+            assertNotNull(http.pluginOrNull(Auth), "Auth must survive on stream client")
+            assertNotNull(
+                http.pluginOrNull(ContentNegotiation),
+                "ContentNegotiation must survive on stream client"
+            )
+            assertNotNull(
+                http.pluginOrNull(HttpRequestRetry),
+                "HttpRequestRetry must survive on stream client"
+            )
+            assertNotNull(
+                http.pluginOrNull(HttpTimeout),
+                "HttpTimeout must survive on stream client"
+            )
+            assertNotNull(http.pluginOrNull(Logging), "Logging must survive on stream client")
+        }
+    }
+
+    @Test
+    fun `httpClient with full replacement drops default plugins`() {
+        val replacement = HttpClient { /* no plugins */ }
+        DeepSeekClient("test-token") {
+            httpClient(replacement)
+        }.use { client ->
+            assertNull(
+                client.client.pluginOrNull(Auth),
+                "Replacement overload must not silently re-add Auth"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `DeepSeekClientBase.Builder.httpClient { block }` now layers the block on top of the existing client via `HttpClient.config(block)` instead of recreating the client from scratch. Defaults (Auth, ContentNegotiation, the base-URL `defaultRequest`, HttpRequestRetry, HttpTimeout, Logging, and SSE on `DeepSeekClientStream`) are preserved, fixing the KDoc/README example that silently produced an unauthenticated client pointing nowhere.
- The `httpClient(client: HttpClient)` overload keeps its replace semantics and is now explicitly documented as such.
- New `commonTest` suite `DeepSeekClientBuilderTests` covers plugin preservation on both client flavours, SSE on the streaming client, and the replace-overload regression.

Addresses finding 1.1 from the repository audit.

## Test plan
- [x] `./gradlew :deepseek-kotlin:jvmTest` — all three new tests pass; existing `ChatCompletionTests` remain green
- [x] `./gradlew :deepseek-kotlin:compileTestKotlinWasmJs` — commonTest compiles for wasmJs
- [x] `./gradlew :deepseek-kotlin:compileTestKotlinMacosArm64` — commonTest compiles for Native