### PR TITLE
use exponential backoff with jitter for retry delay

### DIFF
--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
@@ -14,8 +14,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonBuilder
 import kotlinx.serialization.json.JsonNamingStrategy
 import org.oremif.deepseek.models.DeepSeekParams
+import org.oremif.deepseek.utils.computeRetryDelayMillis
 import org.oremif.deepseek.utils.isRetryableStatus
-import kotlin.random.Random
 
 /**
  * Creates a new instance of [DeepSeekClient] with optional configuration.
@@ -269,9 +269,8 @@ public abstract class DeepSeekClientBase(
                 maxRetries = 3
                 retryIf { _, response -> isRetryableStatus(response.status.value) }
                 retryOnException(maxRetries = 3, retryOnTimeout = true)
-                delayMillis { retry ->
-                    val delay = (retry * 0.2).toLong().coerceAtLeast(1L)
-                    retry + Random.nextLong(delay)
+                delayMillis(respectRetryAfterHeader = true) { retry ->
+                    computeRetryDelayMillis(retry)
                 }
             }
 

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/utils/retry.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/utils/retry.kt
@@ -1,4 +1,31 @@
 package org.oremif.deepseek.utils
 
+import kotlin.random.Random
+
 internal fun isRetryableStatus(statusCode: Int): Boolean =
     statusCode == 408 || statusCode == 425 || statusCode == 429 || statusCode in 500..599
+
+internal const val DEFAULT_RETRY_BASE_MILLIS: Long = 500L
+internal const val DEFAULT_RETRY_MAX_MILLIS: Long = 30_000L
+internal const val DEFAULT_RETRY_JITTER_MILLIS: Long = 250L
+
+/**
+ * Exponential backoff with jitter.
+ *
+ * Delay formula: `min(baseMillis * 2^retry, maxMillis) + Random.nextLong(jitterMillis)`.
+ * `retry` is clamped to [1, 30] so `baseMillis shl retry` never overflows `Long`.
+ * The [maxMillis] cap also protects against runaway delays when the plugin is configured
+ * with a large `maxRetries`.
+ */
+internal fun computeRetryDelayMillis(
+    retry: Int,
+    baseMillis: Long = DEFAULT_RETRY_BASE_MILLIS,
+    maxMillis: Long = DEFAULT_RETRY_MAX_MILLIS,
+    jitterMillis: Long = DEFAULT_RETRY_JITTER_MILLIS,
+    random: Random = Random.Default,
+): Long {
+    val shift = retry.coerceIn(1, 30)
+    val exponential = (baseMillis shl shift).coerceAtMost(maxMillis)
+    val jitter = if (jitterMillis > 0L) random.nextLong(jitterMillis) else 0L
+    return exponential + jitter
+}

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/utils/RetryPolicyTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/utils/RetryPolicyTests.kt
@@ -1,6 +1,8 @@
 package org.oremif.deepseek.utils
 
+import kotlin.random.Random
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -72,5 +74,74 @@ class RetryPolicyTests {
         assertFalse(isRetryableStatus(301))
         assertFalse(isRetryableStatus(302))
         assertFalse(isRetryableStatus(304))
+    }
+
+    @Test
+    fun `delay grows exponentially with retry count`() {
+        val base = 500L
+        val d1 = computeRetryDelayMillis(retry = 1, baseMillis = base, jitterMillis = 0L)
+        val d2 = computeRetryDelayMillis(retry = 2, baseMillis = base, jitterMillis = 0L)
+        val d3 = computeRetryDelayMillis(retry = 3, baseMillis = base, jitterMillis = 0L)
+        assertEquals(1_000L, d1, "retry=1 should yield base * 2^1")
+        assertEquals(2_000L, d2, "retry=2 should yield base * 2^2")
+        assertEquals(4_000L, d3, "retry=3 should yield base * 2^3")
+    }
+
+    @Test
+    fun `delay is capped at maxMillis`() {
+        val d = computeRetryDelayMillis(
+            retry = 10,
+            baseMillis = 500L,
+            maxMillis = 5_000L,
+            jitterMillis = 0L,
+        )
+        assertEquals(5_000L, d, "exponential term must be clamped to maxMillis")
+    }
+
+    @Test
+    fun `delay does not overflow for large retry counts`() {
+        val d = computeRetryDelayMillis(
+            retry = 60,
+            baseMillis = 500L,
+            maxMillis = 30_000L,
+            jitterMillis = 0L,
+        )
+        assertEquals(30_000L, d, "large retry counts must still clamp to maxMillis, not overflow")
+    }
+
+    @Test
+    fun `jitter stays within configured bound`() {
+        val base = 500L
+        val jitter = 250L
+        repeat(50) { seed ->
+            val d = computeRetryDelayMillis(
+                retry = 1,
+                baseMillis = base,
+                jitterMillis = jitter,
+                random = Random(seed.toLong()),
+            )
+            assertTrue(d >= 1_000L, "delay $d must be >= exponential floor 1000 (seed=$seed)")
+            assertTrue(d < 1_000L + jitter, "delay $d must be < 1000 + jitter=$jitter (seed=$seed)")
+        }
+    }
+
+    @Test
+    fun `zero jitter is deterministic`() {
+        val d1 = computeRetryDelayMillis(retry = 2, baseMillis = 500L, jitterMillis = 0L)
+        val d2 = computeRetryDelayMillis(retry = 2, baseMillis = 500L, jitterMillis = 0L)
+        assertEquals(d1, d2)
+        assertEquals(2_000L, d1)
+    }
+
+    @Test
+    fun `same seed produces same delay`() {
+        val seed = 42L
+        val d1 = computeRetryDelayMillis(
+            retry = 2, baseMillis = 500L, jitterMillis = 250L, random = Random(seed),
+        )
+        val d2 = computeRetryDelayMillis(
+            retry = 2, baseMillis = 500L, jitterMillis = 250L, random = Random(seed),
+        )
+        assertEquals(d1, d2, "same seed must produce deterministic delay")
     }
 }


### PR DESCRIPTION
## Summary
- `HttpRequestRetry.delayMillis` previously computed `(retry * 0.2).toLong().coerceAtLeast(1L)` which collapses to `1` for the first few retries, so the client waited ~1–3 ms between retries and hammered the API on `429`/`5xx`.
- Replaces the formula with a new `computeRetryDelayMillis(retry)` helper: `min(baseMillis shl retry, maxMillis) + Random.nextLong(jitterMillis)`. Defaults: 500 ms base, 30 s cap, 250 ms jitter → waits of ~1 s / 2 s / 4 s for retries 1..3.
- `retry` is clamped to `[1, 30]` so the left shift cannot overflow `Long`; `maxMillis` caps any remaining growth.
- `respectRetryAfterHeader = true` stays enabled (Ktor default, now explicit) so servers that return `Retry-After` still drive the delay.

## Test plan
- [x] `./gradlew :deepseek-kotlin:jvmTest` — 27 tests, 0 failures (18 in `RetryPolicyTests`: exponential growth, cap, large-retry overflow guard, jitter bound, zero-jitter determinism, same-seed determinism).
- [x] `./gradlew :deepseek-kotlin:compileCommonMainKotlinMetadata :deepseek-kotlin:compileKotlinWasmJs :deepseek-kotlin:compileKotlinIosArm64` — all green.