### PR TITLE
add suspend closeAndJoin for non-blocking client shutdown

### DIFF
--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
@@ -9,6 +9,7 @@ import io.ktor.client.plugins.logging.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.job
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonBuilder
@@ -298,10 +299,28 @@ public abstract class DeepSeekClientBase(
      * releases threads and connections if they remain idle. Call this only if you need to
      * aggressively free resources (e.g. during application shutdown).
      *
+     * **Blocking:** on some Ktor engines (notably CIO) this may block the calling thread
+     * while in-flight requests and the engine's internal coroutines finish. Prefer
+     * [closeAndJoin] from a coroutine context to avoid blocking.
+     *
      * The client cannot be reused after [close] is called.
      */
     public open fun close() {
         client.close()
+    }
+
+    /**
+     * Closes the underlying HTTP client and suspends until its coroutine scope completes.
+     *
+     * Prefer this over [close] when called from a coroutine context: it avoids blocking
+     * the calling thread while in-flight requests and the engine's internal coroutines
+     * finish.
+     *
+     * The client cannot be reused after [closeAndJoin] is called.
+     */
+    public open suspend fun closeAndJoin() {
+        client.close()
+        client.coroutineContext.job.join()
     }
 }
 

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/client/DeepSeekClientLifecycleTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/client/DeepSeekClientLifecycleTests.kt
@@ -1,0 +1,28 @@
+package org.oremif.deepseek.client
+
+import kotlinx.coroutines.job
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DeepSeekClientLifecycleTests {
+
+    @Test
+    fun `closeAndJoin completes the client coroutine scope`() = runTest {
+        val client = DeepSeekClient("test-token")
+        val job = client.client.coroutineContext.job
+        client.closeAndJoin()
+        assertTrue(job.isCompleted, "Client coroutine scope must complete after closeAndJoin")
+    }
+
+    @Test
+    fun `closeAndJoin completes the stream client coroutine scope`() = runTest {
+        val client = DeepSeekClientStream("test-token")
+        val job = client.client.coroutineContext.job
+        client.closeAndJoin()
+        assertTrue(
+            job.isCompleted,
+            "Stream client coroutine scope must complete after closeAndJoin"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- `HttpClient.close()` may block the calling thread on some Ktor engines (notably CIO) while in-flight requests and internal engine coroutines finish. Added a `suspend fun closeAndJoin()` on `DeepSeekClientBase` that calls `client.close()` and awaits the client's coroutine scope (`client.coroutineContext.job.join()`), so callers in a coroutine context can shut the client down without blocking a thread.
- Documented the blocking behaviour of `close()` in its KDoc and cross-referenced `closeAndJoin()` as the non-blocking alternative.
- Addresses finding 1.7 from `findings.md`.

## Test plan
- [x] `./gradlew :deepseek-kotlin:jvmTest` passes
- [x] New `DeepSeekClientLifecycleTests` (commonTest) covers `closeAndJoin()` on both `DeepSeekClient` and `DeepSeekClientStream`, asserting the client's coroutine job reaches the completed state