### PR TITLE
hide internal HttpClient from public API

### DIFF
--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
@@ -77,11 +77,10 @@ public fun DeepSeekClientStream(
  * lifetime of your application. The underlying HTTP client automatically releases idle
  * connections and threads, so calling [close] is usually unnecessary.
  *
- * @property client The underlying HTTP client used for API requests
  * @property config Configuration options for the DeepSeek client
  */
 public abstract class DeepSeekClientBase(
-    public val client: HttpClient, public val config: DeepSeekClientConfig,
+    internal val client: HttpClient, public val config: DeepSeekClientConfig,
 ) {
 
     /**


### PR DESCRIPTION
## Summary
- Make `DeepSeekClientBase.client: HttpClient` `internal` so the Ktor client stops leaking into the SDK's public surface.
- `config` stays `public` — only the HTTP client was called out in `findings.md` §1.8 as a leak.
- API extensions in `api/*.kt` and `commonTest` still compile: `internal` is module-scoped and no `inline` function escapes it, so `@PublishedApi` isn't needed.

## Test plan
- [x] `./gradlew :deepseek-kotlin:compileCommonMainKotlinMetadata`
- [x] `./gradlew :deepseek-kotlin:jvmTest --rerun-tasks`