### PR TITLE
set explicit connect/request timeout defaults in HttpTimeout

### DIFF
--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
@@ -266,6 +266,8 @@ public abstract class DeepSeekClientBase(
             }
 
             install(HttpTimeout) {
+                requestTimeoutMillis = 600_000L
+                connectTimeoutMillis = 30_000L
                 socketTimeoutMillis = 300_000L
             }
 

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
@@ -266,8 +266,8 @@ public abstract class DeepSeekClientBase(
             }
 
             install(HttpTimeout) {
-                requestTimeoutMillis = 600_000L
-                connectTimeoutMillis = 30_000L
+                requestTimeoutMillis = 60_000L
+                connectTimeoutMillis = 10_000L
                 socketTimeoutMillis = 300_000L
             }
 


### PR DESCRIPTION
## Summary

Addresses finding **1.9** from `findings.md`: `install(HttpTimeout)` previously set only `socketTimeoutMillis`, leaving `connectTimeoutMillis` and `requestTimeoutMillis` to engine defaults that diverge across OkHttp / Darwin / CIO / JS fetch. Endpoints that don't wrap the call in `timeout { }` (`userBalance()`, `models()`) inherited whatever the engine picked — anywhere from 10 s to effectively infinite.

Pin all three timeouts at the plugin level:

- `connectTimeoutMillis = 10_000` — matches the OpenAI / Anthropic SDK and OkHttp defaults, ≥5× over a real TLS-handshake, consistent on every engine.
- `requestTimeoutMillis = 60_000` — in practice only bounds `userBalance()` / `models()`. `chat*` / `fimCompletion*` supply their own tighter per-request `requestTimeoutMillis` (45 s / 60 s) via `timeout { }`, which Ktor applies in preference to the plugin value (see `HttpTimeout.kt:155-157` in Ktor 3.4.2). SSE is excluded from `requestTimeoutMillis` entirely by `HttpRequestBuilder.supportsRequestTimeout`, so long-lived streams stay unbounded here.
- `socketTimeoutMillis = 300_000` — unchanged; packet-idle bound, matters for streams.

## Test plan

- [x] `./gradlew :deepseek-kotlin:build` — green on JVM, iOS simulator arm64, macOS arm64, Linux (klib), mingw, wasmJs (node + browser).
- [x] Existing `DeepSeekClientBuilderTests` verifying `HttpTimeout` plugin presence still pass.
- [ ] Manual smoke test against the real DeepSeek API to confirm per-request overrides still apply (optional; Ktor plugin behaviour is unit-tested upstream).