### PR TITLE
make HTTP logging opt-in via logging { } DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,7 @@ val chatCompletion = client.chat("Say this is a test")
 Configure the client:
 
 ```kotlin
-import io.ktor.client.plugins.logging.DEFAULT
 import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logger
-import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.plugins.sse.SSE
 import org.oremif.deepseek.client.DeepSeekClient
 
 val deepseekApiKey = System.getenv("DEEPSEEK_API_KEY")
@@ -54,13 +50,12 @@ val client = DeepSeekClient(deepseekApiKey) {
         ignoreUnknownKeys = true
         prettyPrint = false
     }
-    httpClient {
-        install(SSE)
-        install(Logging) {
-            logger = Logger.DEFAULT
-            level = LogLevel.HEADERS
-            sanitizeHeader { header -> header == "Authorization" }
-        }
+
+    // Logging is opt-in. `Authorization` is always redacted; add your own
+    // predicates with `sanitizeHeader { }` for any other sensitive headers.
+    logging {
+        level = LogLevel.HEADERS
+        sanitizeHeader { header -> header == "Cookie" }
     }
 
     chatCompletionTimeout(10_000)

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
@@ -119,6 +119,7 @@ public abstract class DeepSeekClientBase(
 
         private val httpClientConfigBlocks: MutableList<HttpClientConfig<*>.() -> Unit> = mutableListOf()
         private var httpClientOverride: HttpClient? = null
+        private var loggingConfig: LoggingConfig? = null
 
         public fun baseUrl(url: String): Builder {
             deepSeekBaseUrl = url
@@ -239,6 +240,35 @@ public abstract class DeepSeekClientBase(
         }
 
         /**
+         * Enables and configures HTTP request/response logging.
+         *
+         * Logging is **disabled by default** — by design, nothing is logged unless this method
+         * is called. Any number of [sanitizeHeader][LoggingConfig.sanitizeHeader] predicates
+         * can be added; the `Authorization` header is always redacted regardless of the
+         * configured predicates.
+         *
+         * Calling this method multiple times keeps the same [LoggingConfig] and applies each
+         * [block] on top of the previous state.
+         *
+         * Example:
+         * ```kotlin
+         * val client = DeepSeekClient("token") {
+         *     logging {
+         *         level = LogLevel.BODY
+         *         sanitizeHeader { header -> header == "Cookie" }
+         *     }
+         * }
+         * ```
+         *
+         * @param block Configuration block receiving a [LoggingConfig]
+         * @return This builder for chaining
+         */
+        public fun logging(block: LoggingConfig.() -> Unit = {}): Builder {
+            loggingConfig = (loggingConfig ?: LoggingConfig()).apply(block)
+            return this
+        }
+
+        /**
          * Builds the default HTTP client with the accumulated [jsonConfig], [deepSeekBaseUrl],
          * and [token]. Subclasses override to layer additional plugins (e.g. SSE for the
          * streaming client) on top.
@@ -271,10 +301,15 @@ public abstract class DeepSeekClientBase(
                 socketTimeoutMillis = 300_000L
             }
 
-            install(Logging) {
-                logger = Logger.DEFAULT
-                level = LogLevel.HEADERS
-                sanitizeHeader { header -> header == "Authorization" }
+            loggingConfig?.let { cfg ->
+                install(Logging) {
+                    logger = cfg.logger
+                    level = cfg.level
+                    sanitizeHeader { header -> header == HttpHeaders.Authorization }
+                    for (predicate in cfg.sanitizers) {
+                        sanitizeHeader { header -> predicate(header) }
+                    }
+                }
             }
         }
 

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/LoggingConfig.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/LoggingConfig.kt
@@ -1,0 +1,44 @@
+package org.oremif.deepseek.client
+
+import io.ktor.client.plugins.logging.DEFAULT
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+
+/**
+ * Configuration for HTTP request/response logging.
+ *
+ * Obtained via the [DeepSeekClientBase.Builder.logging] DSL. Logging is opt-in — create a
+ * [LoggingConfig] by calling `logging { }` on the builder; otherwise nothing is logged.
+ *
+ * Example:
+ * ```kotlin
+ * val client = DeepSeekClient("token") {
+ *     logging {
+ *         level = LogLevel.BODY
+ *         sanitizeHeader { header -> header == "Cookie" }
+ *     }
+ * }
+ * ```
+ *
+ * @property level Log level controlling what is logged. Defaults to [LogLevel.HEADERS].
+ * @property logger Destination for log lines. Defaults to [Logger.DEFAULT].
+ */
+public class LoggingConfig internal constructor() {
+    public var level: LogLevel = LogLevel.HEADERS
+    public var logger: Logger = Logger.DEFAULT
+
+    internal val sanitizers: MutableList<(String) -> Boolean> = mutableListOf()
+
+    /**
+     * Redacts headers whose name satisfies [predicate] from log output.
+     *
+     * Can be called multiple times to register several predicates — a header is redacted if
+     * any predicate returns `true`. The `Authorization` header is always redacted regardless
+     * of the configured predicates.
+     *
+     * @param predicate Returns `true` to redact the header with the given name
+     */
+    public fun sanitizeHeader(predicate: (String) -> Boolean) {
+        sanitizers += predicate
+    }
+}

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/client/DeepSeekClientBuilderTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/client/DeepSeekClientBuilderTests.kt
@@ -5,12 +5,14 @@ import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.pluginOrNull
 import io.ktor.client.plugins.sse.SSE
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -42,7 +44,6 @@ class DeepSeekClientBuilderTests {
                 "HttpRequestRetry must survive httpClient { }"
             )
             assertNotNull(http.pluginOrNull(HttpTimeout), "HttpTimeout must survive httpClient { }")
-            assertNotNull(http.pluginOrNull(Logging), "Logging must survive httpClient { }")
         }
     }
 
@@ -66,8 +67,74 @@ class DeepSeekClientBuilderTests {
                 http.pluginOrNull(HttpTimeout),
                 "HttpTimeout must survive on stream client"
             )
-            assertNotNull(http.pluginOrNull(Logging), "Logging must survive on stream client")
         }
+    }
+
+    @Test
+    fun `logging is not installed by default`() {
+        DeepSeekClient("test-token").use { client ->
+            assertNull(
+                client.client.pluginOrNull(Logging),
+                "Logging plugin must be opt-in — nothing should be logged by default"
+            )
+        }
+    }
+
+    @Test
+    fun `logging block installs Logging plugin`() {
+        DeepSeekClient("test-token") {
+            logging { level = LogLevel.BODY }
+        }.use { client ->
+            assertNotNull(
+                client.client.pluginOrNull(Logging),
+                "logging { } must install the Logging plugin"
+            )
+        }
+    }
+
+    @Test
+    fun `logging block with no args installs Logging with defaults`() {
+        DeepSeekClient("test-token") {
+            logging()
+        }.use { client ->
+            assertNotNull(
+                client.client.pluginOrNull(Logging),
+                "logging() with no block must still install the plugin"
+            )
+        }
+    }
+
+    @Test
+    fun `logging block applies to stream client and survives httpClient block`() {
+        DeepSeekClientStream("test-token") {
+            logging { level = LogLevel.HEADERS }
+            httpClient { /* additive configuration — intentionally empty */ }
+        }.use { client ->
+            assertNotNull(
+                client.client.pluginOrNull(Logging),
+                "Logging from logging { } must survive layered httpClient { } on stream client"
+            )
+            assertNotNull(
+                client.client.pluginOrNull(SSE),
+                "SSE must survive alongside logging { } on stream client"
+            )
+        }
+    }
+
+    @Test
+    fun `logging block can be called multiple times and accumulates sanitizers`() {
+        var calls = 0
+        DeepSeekClient("test-token") {
+            logging { level = LogLevel.BODY }
+            logging {
+                sanitizeHeader { header -> header == "Cookie" }
+                sanitizeHeader { header -> header == "X-Trace-Id" }
+            }
+        }.use { client ->
+            calls++
+            assertNotNull(client.client.pluginOrNull(Logging))
+        }
+        assertEquals(1, calls)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `Logging` plugin is no longer installed by default. Every header (except `Authorization`) was being surfaced at `LogLevel.HEADERS` — noisy for library consumers and a leak risk for `Cookie` / `X-Request-Id` / custom auth headers.
- New opt-in builder DSL: `logging { level = ...; sanitizeHeader { … } }`. `Authorization` stays redacted unconditionally whenever logging is enabled; user predicates accumulate on top.
- Public `LoggingConfig` added to the `client` package; `logging(block = {})` keeps the same config across repeated calls, layering each block on top.
- README example swapped from `httpClient { install(Logging) { … } }` to the new DSL.

Addresses finding 1.10 from `findings.md`.

## Test plan

- [x] `./gradlew :deepseek-kotlin:jvmTest` — 12/12 pass, including 5 new cases:
  - `logging` is not installed by default
  - `logging { }` installs the plugin
  - `logging()` with no block installs with defaults
  - DSL works alongside `httpClient { }` on `DeepSeekClientStream`
  - Repeated `logging { }` calls keep the same config
- [x] `./gradlew :deepseek-kotlin:compileKotlinWasmJs :deepseek-kotlin:compileKotlinIosArm64 :deepseek-kotlin:compileKotlinLinuxX64` — all green (`Logger.DEFAULT` resolves via `io.ktor.client.plugins.logging.DEFAULT` extension on every target).