### PR TITLE
disable lenient JSON parsing by default

### DIFF
--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/client/DeepSeekClient.kt
@@ -102,7 +102,6 @@ public abstract class DeepSeekClientBase(
         @OptIn(ExperimentalSerializationApi::class)
         protected var jsonConfig: Json = Json {
             prettyPrint = true
-            isLenient = true
             ignoreUnknownKeys = true
             namingStrategy = JsonNamingStrategy.SnakeCase
         }


### PR DESCRIPTION
## Summary
- Remove `isLenient = true` from the default `Json { }` builder in `DeepSeekClient` so the SDK parses strict JSON by default.
- `ignoreUnknownKeys = true` is kept for forward compatibility with new server fields.

## Why
`isLenient = true` silently accepts non-standard JSON (unquoted keys, numbers in strings, etc.). For a production SDK against a typed API this hides server-side format regressions instead of surfacing them. Users who need lenient parsing can still opt in via `jsonConfig { isLenient = true }`.

## Test plan
- [x] `./gradlew :deepseek-kotlin:jvmTest --rerun-tasks` passes
- [x] Existing `jsonConfig` tests in `DeepSeekClientBuilderTests` still pass (one of them already sets `isLenient = false` explicitly)