### PR TITLE
propagate SSE errors and parse response body

### DIFF
--- a/deepseek-kotlin/build.gradle.kts
+++ b/deepseek-kotlin/build.gradle.kts
@@ -75,6 +75,7 @@ kotlin {
             dependencies {
                 implementation(libs.kotlin.test)
                 implementation(libs.coroutines.test)
+                implementation(libs.ktor.client.mock)
             }
         }
 

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/api/chatStream.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/api/chatStream.kt
@@ -3,11 +3,13 @@ package org.oremif.deepseek.api
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.oremif.deepseek.client.DeepSeekClientBase
 import org.oremif.deepseek.client.DeepSeekClientStream
+import org.oremif.deepseek.errors.DeepSeekError
 import org.oremif.deepseek.errors.DeepSeekException
 import org.oremif.deepseek.models.*
 
@@ -60,9 +62,11 @@ public suspend fun DeepSeekClientBase.chatCompletionStream(request: ChatCompleti
                 }
             }
         } catch (e: SSEClientException) {
-            e.response?.let { response ->
-                throw DeepSeekException.from(response.status.value, response.headers, null)
-            }
+            val response = e.response ?: throw e
+            val error = runCatching {
+                config.jsonConfig.decodeFromString<DeepSeekError>(response.bodyAsText())
+            }.getOrNull()
+            throw DeepSeekException.from(response.status.value, response.headers, error)
         }
     }
 }

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/api/fimCompletionStream.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/api/fimCompletionStream.kt
@@ -3,16 +3,17 @@ package org.oremif.deepseek.api
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.sse.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.oremif.deepseek.client.DeepSeekClientBase
 import org.oremif.deepseek.client.DeepSeekClientStream
+import org.oremif.deepseek.errors.DeepSeekError
 import org.oremif.deepseek.errors.DeepSeekException
 import org.oremif.deepseek.models.FIMCompletion
 import org.oremif.deepseek.models.FIMCompletionParams
 import org.oremif.deepseek.models.FIMCompletionRequest
-import kotlin.time.Duration.Companion.minutes
 
 /**
  * Streams Fill-In-the-Middle (FIM) completions chunk by chunk from the DeepSeek API.
@@ -63,9 +64,11 @@ public suspend fun DeepSeekClientBase.fimCompletionStream(request: FIMCompletion
                 }
             }
         } catch (e: SSEClientException) {
-            e.response?.let { response ->
-                throw DeepSeekException.from(response.status.value, response.headers, null)
-            }
+            val response = e.response ?: throw e
+            val error = runCatching {
+                config.jsonConfig.decodeFromString<DeepSeekError>(response.bodyAsText())
+            }.getOrNull()
+            throw DeepSeekException.from(response.status.value, response.headers, error)
         }
     }
 }

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/StreamErrorTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/StreamErrorTests.kt
@@ -1,0 +1,189 @@
+package org.oremif.deepseek.api
+
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.sse.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNamingStrategy
+import org.oremif.deepseek.client.DeepSeekClientStream
+import org.oremif.deepseek.errors.DeepSeekException
+import org.oremif.deepseek.models.ChatCompletionRequest
+import org.oremif.deepseek.models.ChatModel
+import org.oremif.deepseek.models.FIMCompletionRequest
+import org.oremif.deepseek.models.UserMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private class SseMockEngine(config: MockEngineConfig) : MockEngine(config) {
+    override val supportedCapabilities: Set<HttpClientEngineCapability<out Any>> =
+        super.supportedCapabilities + SSECapability
+}
+
+private fun sseMockEngine(handler: MockRequestHandler): SseMockEngine =
+    SseMockEngine(MockEngineConfig().apply { requestHandlers.add(handler) })
+
+class StreamErrorTests {
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private val jsonConfig = Json {
+        ignoreUnknownKeys = true
+        namingStrategy = JsonNamingStrategy.SnakeCase
+    }
+
+    private fun streamClient(engine: HttpClientEngine): DeepSeekClientStream {
+        val http = HttpClient(engine) {
+            install(ContentNegotiation) { json(jsonConfig) }
+            install(SSE)
+            defaultRequest {
+                url("https://api.deepseek.com")
+                contentType(ContentType.Application.Json)
+            }
+        }
+        return DeepSeekClientStream {
+            jsonConfig(jsonConfig)
+            httpClient(http)
+        }
+    }
+
+    private val chatRequest = ChatCompletionRequest(
+        messages = listOf(UserMessage("Hi")),
+        model = ChatModel.DEEPSEEK_CHAT,
+        stream = true
+    )
+
+    private val fimRequest = FIMCompletionRequest(
+        model = ChatModel.DEEPSEEK_CHAT,
+        prompt = "def foo():",
+        stream = true
+    )
+
+    @Test
+    fun `chat stream 400 with JSON body becomes BadRequestException with parsed error`() = runTest {
+        val engine = sseMockEngine {
+            respond(
+                content = """{"error":{"message":"Invalid model","type":"invalid_request_error","code":"model_not_found"}}""",
+                status = HttpStatusCode.BadRequest,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = streamClient(engine)
+        val ex = assertFailsWith<DeepSeekException.BadRequestException> {
+            client.chatCompletionStream(chatRequest).toList()
+        }
+        assertEquals(400, ex.statusCode)
+        val error = assertNotNull(ex.error, "error body should be parsed")
+        assertEquals("Invalid model", error.error.message)
+        assertEquals("invalid_request_error", error.error.type)
+        assertEquals("model_not_found", error.error.code)
+    }
+
+    @Test
+    fun `chat stream 401 with JSON body becomes UnauthorizedException`() = runTest {
+        val engine = sseMockEngine {
+            respond(
+                content = """{"error":{"message":"Invalid API key","type":"authentication_error"}}""",
+                status = HttpStatusCode.Unauthorized,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = streamClient(engine)
+        val ex = assertFailsWith<DeepSeekException.UnauthorizedException> {
+            client.chatCompletionStream(chatRequest).toList()
+        }
+        assertEquals(401, ex.statusCode)
+        assertEquals("Invalid API key", ex.error?.error?.message)
+    }
+
+    @Test
+    fun `chat stream 503 maps to OverloadServerException`() = runTest {
+        val engine = sseMockEngine {
+            respond(
+                content = """{"error":{"message":"Server overloaded"}}""",
+                status = HttpStatusCode.ServiceUnavailable,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = streamClient(engine)
+        val ex = assertFailsWith<DeepSeekException.OverloadServerException> {
+            client.chatCompletionStream(chatRequest).toList()
+        }
+        assertEquals("Server overloaded", ex.error?.error?.message)
+    }
+
+    @Test
+    fun `chat stream 500 with non-JSON body still throws typed exception with null error`() = runTest {
+        val engine = sseMockEngine {
+            respond(
+                content = "Internal server error",
+                status = HttpStatusCode.InternalServerError,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString())
+            )
+        }
+        val client = streamClient(engine)
+        val ex = assertFailsWith<DeepSeekException.InternalServerException> {
+            client.chatCompletionStream(chatRequest).toList()
+        }
+        assertEquals(500, ex.statusCode)
+        assertNull(ex.error, "unparsable body must not crash — error should be null")
+    }
+
+    @Test
+    fun `chat stream network error before response propagates instead of being swallowed`() = runTest {
+        val engine = sseMockEngine {
+            throw RuntimeException("Network unreachable")
+        }
+        val client = streamClient(engine)
+        val thrown = assertFailsWith<Throwable> {
+            client.chatCompletionStream(chatRequest).toList()
+        }
+        assertTrue(
+            thrown !is DeepSeekException,
+            "network error must not be wrapped as DeepSeekException when no HTTP response is available"
+        )
+    }
+
+    @Test
+    fun `fim stream 400 with JSON body becomes BadRequestException with parsed error`() = runTest {
+        val engine = sseMockEngine {
+            respond(
+                content = """{"error":{"message":"Bad FIM prompt","type":"invalid_request_error"}}""",
+                status = HttpStatusCode.BadRequest,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = streamClient(engine)
+        val ex = assertFailsWith<DeepSeekException.BadRequestException> {
+            client.fimCompletionStream(fimRequest).toList()
+        }
+        assertEquals(400, ex.statusCode)
+        assertEquals("Bad FIM prompt", ex.error?.error?.message)
+    }
+
+    @Test
+    fun `fim stream network error before response propagates instead of being swallowed`() = runTest {
+        val engine = sseMockEngine {
+            throw RuntimeException("Network unreachable")
+        }
+        val client = streamClient(engine)
+        val thrown = assertFailsWith<Throwable> {
+            client.fimCompletionStream(fimRequest).toList()
+        }
+        assertTrue(
+            thrown !is DeepSeekException,
+            "network error must not be wrapped as DeepSeekException when no HTTP response is available"
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ ktor-client-js = { group = "io.ktor", name = "ktor-client-js", version.ref = "kt
 # Test
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 
 [plugins]


### PR DESCRIPTION
## Summary

Fixes findings 2.1 and 2.2: the `catch (SSEClientException)` blocks in `chatStream.kt` and `fimCompletionStream.kt` swallowed network errors (when `e.response == null` the `let { }` didn't fire and the Flow completed normally without data) and dropped the server-side error body (`DeepSeekException.from(...)` was always called with `error = null`, so callers lost `message`/`type`/`code`).

- Rethrow the original `SSEClientException` when `e.response == null` — network/timeout failures before the first response no longer complete silently.
- Read `response.bodyAsText()` once and deserialize into `DeepSeekError` via `config.jsonConfig`, wrapped in `runCatching` so non-JSON or missing bodies fall back to `error = null` without crashing. Only a single body read, as required by SSE-saved responses.
- Pass the parsed `DeepSeekError` into `DeepSeekException.from(...)` so callers receive the server error payload.
- `CancellationException` is untouched — it isn't an `SSEClientException` and Ktor already rethrows it unwrapped.

## Test plan

New `StreamErrorTests` in `commonTest` using a `MockEngine` subclass that advertises `SSECapability`:

- [x] 400 with JSON body → `BadRequestException` with parsed `message`/`type`/`code`
- [x] 401 with JSON body → `UnauthorizedException` with parsed message
- [x] 503 with JSON body → `OverloadServerException` with parsed message
- [x] 500 with non-JSON body → `InternalServerException`, `error = null` (graceful parse failure)
- [x] Engine throws before response → exception propagates (not a `DeepSeekException`)
- [x] FIM stream mirrors (happy error path + network error)
- [x] `./gradlew :deepseek-kotlin:jvmTest` — all green
- [x] `./gradlew :deepseek-kotlin:macosArm64Test` — all green
- [x] `./gradlew :deepseek-kotlin:wasmJsNodeTest` — all green
- [x] Test sources compile on iosArm64 / linuxX64 / macosArm64 / wasmJs