### PR TITLE
fix OverloadServerException status code and unify from() overloads

### DIFF
--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/errors/DeepSeekError.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/errors/DeepSeekError.kt
@@ -63,7 +63,7 @@ public sealed class DeepSeekException(
 
     public class OverloadServerException(
         headers: Headers, error: DeepSeekError?, message: String?
-    ) : DeepSeekException(500, headers, error, message)
+    ) : DeepSeekException(503, headers, error, message)
 
     public class UnexpectedStatusCodeException(
         statusCode: Int, headers: Headers, error: DeepSeekError?, message: String?
@@ -71,70 +71,37 @@ public sealed class DeepSeekException(
 
     public companion object {
         public fun from(statusCode: Int, headers: Headers, error: DeepSeekError?, message: String): DeepSeekException =
-            when (statusCode) {
-                400 -> BadRequestException(headers, error, message)
-                401 -> UnauthorizedException(headers, error, message)
-                402 -> InsufficientBalanceException(headers, error, message)
-                403 -> PermissionDeniedException(headers, error, message)
-                404 -> NotFoundException(headers, error, message)
-                422 -> UnprocessableEntityException(headers, error, message)
-                429 -> RateLimitException(headers, error, message)
-                500 -> InternalServerException(headers, error, message)
-                else -> UnexpectedStatusCodeException(statusCode, headers, error, message)
-            }
+            create(statusCode, headers, error, message)
 
         public fun from(statusCode: Int, headers: Headers, error: DeepSeekError?): DeepSeekException =
-            when (statusCode) {
-                400 -> BadRequestException(
-                    headers,
-                    error,
-                    "Please modify your request body according to the hints in the error message.\nFor more API format details, please refer to [DeepSeek API Docs](https://api-docs.deepseek.com/)."
-                )
+            create(statusCode, headers, error, defaultMessageFor(statusCode))
 
-                401 -> UnauthorizedException(
-                    headers,
-                    error,
-                    "Please check your API key.\nIf you don't have one, please [create an API key](https://platform.deepseek.com/api_keys) first."
-                )
+        private fun create(
+            statusCode: Int, headers: Headers, error: DeepSeekError?, message: String
+        ): DeepSeekException = when (statusCode) {
+            400 -> BadRequestException(headers, error, message)
+            401 -> UnauthorizedException(headers, error, message)
+            402 -> InsufficientBalanceException(headers, error, message)
+            403 -> PermissionDeniedException(headers, error, message)
+            404 -> NotFoundException(headers, error, message)
+            422 -> UnprocessableEntityException(headers, error, message)
+            429 -> RateLimitException(headers, error, message)
+            500 -> InternalServerException(headers, error, message)
+            503 -> OverloadServerException(headers, error, message)
+            else -> UnexpectedStatusCodeException(statusCode, headers, error, message)
+        }
 
-                402 -> InsufficientBalanceException(
-                    headers,
-                    error,
-                    "Please check your account's balance, and go to the [Top up](https://platform.deepseek.com/top_up) page to add funds."
-                )
-
-                403 -> PermissionDeniedException(
-                    headers,
-                    error,
-                    "Please check your API key.\nIf you don't have one, please [create an API key](https://platform.deepseek.com/api_keys) first."
-                )
-
-                404 -> NotFoundException(
-                    headers,
-                    error,
-                    "Please check the API endpoint you are using.\nFor more API format details, please refer to [DeepSeek API Docs](https://api-docs.deepseek.com/)."
-                )
-
-                422 -> UnprocessableEntityException(
-                    headers,
-                    error,
-                    "Please modify your request parameters according to the hints in the error message.\nFor more API format details, please refer to [DeepSeek API Docs](https://api-docs.deepseek.com/)."
-                )
-
-                429 -> RateLimitException(
-                    headers,
-                    error,
-                    "Please pace your requests reasonably.\nWe also advise users to temporarily switch to the APIs of alternative LLM service providers, like OpenAI."
-                )
-
-                500 -> InternalServerException(
-                    headers,
-                    error,
-                    "Please retry your request after a brief wait and contact us if the issue persists."
-                )
-
-                503 -> OverloadServerException(headers, error, "Please retry your request after a brief wait.")
-                else -> UnexpectedStatusCodeException(statusCode, headers, error, "Unexpected status code: $statusCode")
-            }
+        private fun defaultMessageFor(statusCode: Int): String = when (statusCode) {
+            400 -> "Please modify your request body according to the hints in the error message.\nFor more API format details, please refer to [DeepSeek API Docs](https://api-docs.deepseek.com/)."
+            401 -> "Please check your API key.\nIf you don't have one, please [create an API key](https://platform.deepseek.com/api_keys) first."
+            402 -> "Please check your account's balance, and go to the [Top up](https://platform.deepseek.com/top_up) page to add funds."
+            403 -> "Please check your API key.\nIf you don't have one, please [create an API key](https://platform.deepseek.com/api_keys) first."
+            404 -> "Please check the API endpoint you are using.\nFor more API format details, please refer to [DeepSeek API Docs](https://api-docs.deepseek.com/)."
+            422 -> "Please modify your request parameters according to the hints in the error message.\nFor more API format details, please refer to [DeepSeek API Docs](https://api-docs.deepseek.com/)."
+            429 -> "Please pace your requests reasonably.\nWe also advise users to temporarily switch to the APIs of alternative LLM service providers, like OpenAI."
+            500 -> "Please retry your request after a brief wait and contact us if the issue persists."
+            503 -> "Please retry your request after a brief wait."
+            else -> "Unexpected status code: $statusCode"
+        }
     }
 }

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/StreamErrorTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/StreamErrorTests.kt
@@ -120,6 +120,7 @@ class StreamErrorTests {
         val ex = assertFailsWith<DeepSeekException.OverloadServerException> {
             client.chatCompletionStream(chatRequest).toList()
         }
+        assertEquals(503, ex.statusCode)
         assertEquals("Server overloaded", ex.error?.error?.message)
     }
 

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekExceptionTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekExceptionTests.kt
@@ -1,0 +1,32 @@
+package org.oremif.deepseek.errors
+
+import io.ktor.http.Headers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DeepSeekExceptionTests {
+
+    @Test
+    fun `OverloadServerException exposes 503 as statusCode`() {
+        val ex = DeepSeekException.OverloadServerException(Headers.Empty, null, "overloaded")
+        assertEquals(503, ex.statusCode)
+    }
+
+    @Test
+    fun `from with 4 args maps 503 to OverloadServerException`() {
+        val ex = DeepSeekException.from(503, Headers.Empty, null, "Service Unavailable")
+        assertTrue(
+            ex is DeepSeekException.OverloadServerException,
+            "expected OverloadServerException, got ${ex::class.simpleName}"
+        )
+        assertEquals(503, ex.statusCode)
+    }
+
+    @Test
+    fun `both from overloads return OverloadServerException for 503`() {
+        val fromShort = DeepSeekException.from(503, Headers.Empty, null)
+        val fromLong = DeepSeekException.from(503, Headers.Empty, null, "Service Unavailable")
+        assertEquals(fromShort::class, fromLong::class)
+    }
+}


### PR DESCRIPTION
## Summary

- `OverloadServerException` declared `statusCode = 500`, but it's the exception returned for HTTP 503. Any code filtering by `ex.statusCode == 503` silently fell through. Now it's `super(503, …)`.
- The 4-arg `DeepSeekException.from()` had no `503` branch, while the 3-arg overload did. `validateResponse` picks the overload based on `HttpStatusCode.description.isEmpty()`, so the same 503 response mapped to either `OverloadServerException` or `UnexpectedStatusCodeException` depending on the engine/response. Both overloads now delegate to one shared private `create()`; default messages are extracted into `defaultMessageFor()`.

Fixes 2.3 and 2.4 from the audit findings.

## Test plan

- [x] New `errors/DeepSeekExceptionTests.kt` covers: `OverloadServerException.statusCode == 503`, 4-arg `from(503, …)` returns `OverloadServerException`, both overloads return the same type for 503.
- [x] Existing `chat stream 503 maps to OverloadServerException` now also asserts `ex.statusCode == 503` (previously it would have passed against the buggy code).
- [x] All 4 tests fail on `master`, pass on this branch (`./gradlew :deepseek-kotlin:jvmTest` → 44/44 green).
- [x] `compileKotlinWasmJs` + `compileTestKotlinWasmJs` clean.