### PR TITLE
fix DeepSeekException message formatting to drop leading newline and null text

### DIFF
--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/errors/DeepSeekError.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/errors/DeepSeekError.kt
@@ -27,7 +27,7 @@ public sealed class DeepSeekException(
     public val error: DeepSeekError?,
     message: String? = null,
     cause: Throwable? = null,
-) : RuntimeException("${error?.error?.message ?: ""}\n$message", cause) {
+) : RuntimeException(listOfNotNull(error?.error?.message, message).joinToString("\n"), cause) {
 
     public class BadRequestException(
         headers: Headers, error: DeepSeekError?, message: String?

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekExceptionTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekExceptionTests.kt
@@ -29,4 +29,30 @@ class DeepSeekExceptionTests {
         val fromLong = DeepSeekException.from(503, Headers.Empty, null, "Service Unavailable")
         assertEquals(fromShort::class, fromLong::class)
     }
+
+    @Test
+    fun `message has no leading newline when error is null`() {
+        val ex = DeepSeekException.from(401, Headers.Empty, null, "Please check your API key.")
+        assertEquals("Please check your API key.", ex.message)
+    }
+
+    @Test
+    fun `message is empty when both error and fallback message are absent`() {
+        val ex = DeepSeekException.UnexpectedStatusCodeException(418, Headers.Empty, null, null)
+        assertEquals("", ex.message)
+    }
+
+    @Test
+    fun `message contains only error message when fallback message is null`() {
+        val error = DeepSeekError(DeepSeekError.Error(message = "Invalid API key"))
+        val ex = DeepSeekException.UnexpectedStatusCodeException(418, Headers.Empty, error, null)
+        assertEquals("Invalid API key", ex.message)
+    }
+
+    @Test
+    fun `message joins error and fallback with newline when both present`() {
+        val error = DeepSeekError(DeepSeekError.Error(message = "Invalid API key"))
+        val ex = DeepSeekException.from(401, Headers.Empty, error, "Please check your API key.")
+        assertEquals("Invalid API key\nPlease check your API key.", ex.message)
+    }
 }


### PR DESCRIPTION
## Summary
- `DeepSeekException` built its `message` as `"${error?.error?.message ?: ""}\n$message"`, which produced a leading `\n` whenever `error` was null, and literally `"\nnull"` when both `error` and `message` were absent (findings.md §2.5).
- Switch to `listOfNotNull(error?.error?.message, message).joinToString("\n")` so the message contains only the parts that actually exist, joined by a single newline.

## Test plan
- [x] `./gradlew :deepseek-kotlin:jvmTest` — all tests pass, including 4 new cases in `DeepSeekExceptionTests` covering: error-only, fallback-only, both present, and both absent.