### PR TITLE
wrap Ktor Headers in DeepSeekHeaders for exception API

### DIFF
--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/api/chatStream.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/api/chatStream.kt
@@ -11,6 +11,7 @@ import org.oremif.deepseek.client.DeepSeekClientBase
 import org.oremif.deepseek.client.DeepSeekClientStream
 import org.oremif.deepseek.errors.DeepSeekError
 import org.oremif.deepseek.errors.DeepSeekException
+import org.oremif.deepseek.errors.toDeepSeekHeaders
 import org.oremif.deepseek.models.*
 
 /**
@@ -66,7 +67,7 @@ public suspend fun DeepSeekClientBase.chatCompletionStream(request: ChatCompleti
             val error = runCatching {
                 config.jsonConfig.decodeFromString<DeepSeekError>(response.bodyAsText())
             }.getOrNull()
-            throw DeepSeekException.from(response.status.value, response.headers, error)
+            throw DeepSeekException.from(response.status.value, response.headers.toDeepSeekHeaders(), error)
         }
     }
 }

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/api/fimCompletionStream.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/api/fimCompletionStream.kt
@@ -11,6 +11,7 @@ import org.oremif.deepseek.client.DeepSeekClientBase
 import org.oremif.deepseek.client.DeepSeekClientStream
 import org.oremif.deepseek.errors.DeepSeekError
 import org.oremif.deepseek.errors.DeepSeekException
+import org.oremif.deepseek.errors.toDeepSeekHeaders
 import org.oremif.deepseek.models.FIMCompletion
 import org.oremif.deepseek.models.FIMCompletionParams
 import org.oremif.deepseek.models.FIMCompletionRequest
@@ -68,7 +69,7 @@ public suspend fun DeepSeekClientBase.fimCompletionStream(request: FIMCompletion
             val error = runCatching {
                 config.jsonConfig.decodeFromString<DeepSeekError>(response.bodyAsText())
             }.getOrNull()
-            throw DeepSeekException.from(response.status.value, response.headers, error)
+            throw DeepSeekException.from(response.status.value, response.headers.toDeepSeekHeaders(), error)
         }
     }
 }

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/errors/DeepSeekError.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/errors/DeepSeekError.kt
@@ -1,6 +1,5 @@
 package org.oremif.deepseek.errors
 
-import io.ktor.http.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
@@ -23,61 +22,63 @@ public class DeepSeekError(
 
 public sealed class DeepSeekException(
     public val statusCode: Int,
-    public val headers: Headers,
+    public val headers: DeepSeekHeaders,
     public val error: DeepSeekError?,
     message: String? = null,
     cause: Throwable? = null,
 ) : RuntimeException(listOfNotNull(error?.error?.message, message).joinToString("\n"), cause) {
 
     public class BadRequestException(
-        headers: Headers, error: DeepSeekError?, message: String?
+        headers: DeepSeekHeaders, error: DeepSeekError?, message: String?
     ) : DeepSeekException(400, headers, error, message)
 
     public class UnauthorizedException(
-        headers: Headers, error: DeepSeekError?, message: String?
+        headers: DeepSeekHeaders, error: DeepSeekError?, message: String?
     ) : DeepSeekException(401, headers, error, message)
 
     public class InsufficientBalanceException(
-        headers: Headers, error: DeepSeekError?, message: String?
+        headers: DeepSeekHeaders, error: DeepSeekError?, message: String?
     ) : DeepSeekException(402, headers, error, message)
 
     public class PermissionDeniedException(
-        headers: Headers, error: DeepSeekError?, message: String?
+        headers: DeepSeekHeaders, error: DeepSeekError?, message: String?
     ) : DeepSeekException(403, headers, error, message)
 
     public class NotFoundException(
-        headers: Headers, error: DeepSeekError?, message: String?
+        headers: DeepSeekHeaders, error: DeepSeekError?, message: String?
     ) : DeepSeekException(404, headers, error, message)
 
     public class UnprocessableEntityException(
-        headers: Headers, error: DeepSeekError?, message: String?
+        headers: DeepSeekHeaders, error: DeepSeekError?, message: String?
     ) : DeepSeekException(422, headers, error, message)
 
     public class RateLimitException(
-        headers: Headers, error: DeepSeekError?, message: String?,
+        headers: DeepSeekHeaders, error: DeepSeekError?, message: String?,
     ) : DeepSeekException(429, headers, error, message)
 
     public class InternalServerException(
-        headers: Headers, error: DeepSeekError?, message: String?
+        headers: DeepSeekHeaders, error: DeepSeekError?, message: String?
     ) : DeepSeekException(500, headers, error, message)
 
     public class OverloadServerException(
-        headers: Headers, error: DeepSeekError?, message: String?
+        headers: DeepSeekHeaders, error: DeepSeekError?, message: String?
     ) : DeepSeekException(503, headers, error, message)
 
     public class UnexpectedStatusCodeException(
-        statusCode: Int, headers: Headers, error: DeepSeekError?, message: String?
+        statusCode: Int, headers: DeepSeekHeaders, error: DeepSeekError?, message: String?
     ) : DeepSeekException(statusCode, headers, error, message)
 
     public companion object {
-        public fun from(statusCode: Int, headers: Headers, error: DeepSeekError?, message: String): DeepSeekException =
+        public fun from(
+            statusCode: Int, headers: DeepSeekHeaders, error: DeepSeekError?, message: String
+        ): DeepSeekException =
             create(statusCode, headers, error, message)
 
-        public fun from(statusCode: Int, headers: Headers, error: DeepSeekError?): DeepSeekException =
+        public fun from(statusCode: Int, headers: DeepSeekHeaders, error: DeepSeekError?): DeepSeekException =
             create(statusCode, headers, error, defaultMessageFor(statusCode))
 
         private fun create(
-            statusCode: Int, headers: Headers, error: DeepSeekError?, message: String
+            statusCode: Int, headers: DeepSeekHeaders, error: DeepSeekError?, message: String
         ): DeepSeekException = when (statusCode) {
             400 -> BadRequestException(headers, error, message)
             401 -> UnauthorizedException(headers, error, message)

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/errors/DeepSeekHeaders.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/errors/DeepSeekHeaders.kt
@@ -1,0 +1,64 @@
+package org.oremif.deepseek.errors
+
+import io.ktor.http.Headers
+
+/**
+ * Immutable, Ktor-free snapshot of HTTP response headers attached to a [DeepSeekException].
+ *
+ * Provided so that error-handling code does not need to depend on `io.ktor.http.Headers`
+ * and remains stable across Ktor major versions.
+ *
+ * Lookups are case-insensitive, matching RFC 7230 semantics. The order of [names] reflects
+ * the insertion order of the backing map.
+ */
+public class DeepSeekHeaders(
+    private val entries: Map<String, List<String>>,
+) {
+    /**
+     * Returns the first value associated with [name] using case-insensitive comparison,
+     * or `null` if the header is not present.
+     */
+    public operator fun get(name: String): String? =
+        findEntry(name)?.value?.firstOrNull()
+
+    /**
+     * Returns all values associated with [name] using case-insensitive comparison,
+     * or an empty list if the header is not present.
+     */
+    public fun getAll(name: String): List<String> =
+        findEntry(name)?.value ?: emptyList()
+
+    /** Returns `true` if the header [name] is present (case-insensitive). */
+    public operator fun contains(name: String): Boolean = findEntry(name) != null
+
+    /** Returns the set of header names as originally supplied (case preserved). */
+    public fun names(): Set<String> = entries.keys
+
+    /** Returns `true` when there are no headers. */
+    public fun isEmpty(): Boolean = entries.isEmpty()
+
+    private fun findEntry(name: String): Map.Entry<String, List<String>>? =
+        entries.entries.firstOrNull { it.key.equals(name, ignoreCase = true) }
+
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is DeepSeekHeaders && entries == other.entries)
+
+    override fun hashCode(): Int = entries.hashCode()
+
+    override fun toString(): String = "DeepSeekHeaders($entries)"
+
+    public companion object {
+        /** A [DeepSeekHeaders] instance with no entries. */
+        public val Empty: DeepSeekHeaders = DeepSeekHeaders(emptyMap())
+    }
+}
+
+internal fun Headers.toDeepSeekHeaders(): DeepSeekHeaders {
+    val names = names()
+    if (names.isEmpty()) return DeepSeekHeaders.Empty
+    val map = LinkedHashMap<String, List<String>>(names.size)
+    for (name in names) {
+        getAll(name)?.let { map[name] = it }
+    }
+    return DeepSeekHeaders(map)
+}

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/utils/validate.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/utils/validate.kt
@@ -5,10 +5,11 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.isSuccess
 import org.oremif.deepseek.errors.DeepSeekError
 import org.oremif.deepseek.errors.DeepSeekException
+import org.oremif.deepseek.errors.toDeepSeekHeaders
 
 internal suspend fun validateResponse(response: HttpResponse) {
     if (!response.status.isSuccess()) {
-        val headers = response.headers
+        val headers = response.headers.toDeepSeekHeaders()
         val error = response.body<DeepSeekError>()
         val description = response.status.description
         throw if (description.isEmpty()) {

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekExceptionTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekExceptionTests.kt
@@ -1,6 +1,5 @@
 package org.oremif.deepseek.errors
 
-import io.ktor.http.Headers
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -9,13 +8,13 @@ class DeepSeekExceptionTests {
 
     @Test
     fun `OverloadServerException exposes 503 as statusCode`() {
-        val ex = DeepSeekException.OverloadServerException(Headers.Empty, null, "overloaded")
+        val ex = DeepSeekException.OverloadServerException(DeepSeekHeaders.Empty, null, "overloaded")
         assertEquals(503, ex.statusCode)
     }
 
     @Test
     fun `from with 4 args maps 503 to OverloadServerException`() {
-        val ex = DeepSeekException.from(503, Headers.Empty, null, "Service Unavailable")
+        val ex = DeepSeekException.from(503, DeepSeekHeaders.Empty, null, "Service Unavailable")
         assertTrue(
             ex is DeepSeekException.OverloadServerException,
             "expected OverloadServerException, got ${ex::class.simpleName}"
@@ -25,34 +24,34 @@ class DeepSeekExceptionTests {
 
     @Test
     fun `both from overloads return OverloadServerException for 503`() {
-        val fromShort = DeepSeekException.from(503, Headers.Empty, null)
-        val fromLong = DeepSeekException.from(503, Headers.Empty, null, "Service Unavailable")
+        val fromShort = DeepSeekException.from(503, DeepSeekHeaders.Empty, null)
+        val fromLong = DeepSeekException.from(503, DeepSeekHeaders.Empty, null, "Service Unavailable")
         assertEquals(fromShort::class, fromLong::class)
     }
 
     @Test
     fun `message has no leading newline when error is null`() {
-        val ex = DeepSeekException.from(401, Headers.Empty, null, "Please check your API key.")
+        val ex = DeepSeekException.from(401, DeepSeekHeaders.Empty, null, "Please check your API key.")
         assertEquals("Please check your API key.", ex.message)
     }
 
     @Test
     fun `message is empty when both error and fallback message are absent`() {
-        val ex = DeepSeekException.UnexpectedStatusCodeException(418, Headers.Empty, null, null)
+        val ex = DeepSeekException.UnexpectedStatusCodeException(418, DeepSeekHeaders.Empty, null, null)
         assertEquals("", ex.message)
     }
 
     @Test
     fun `message contains only error message when fallback message is null`() {
         val error = DeepSeekError(DeepSeekError.Error(message = "Invalid API key"))
-        val ex = DeepSeekException.UnexpectedStatusCodeException(418, Headers.Empty, error, null)
+        val ex = DeepSeekException.UnexpectedStatusCodeException(418, DeepSeekHeaders.Empty, error, null)
         assertEquals("Invalid API key", ex.message)
     }
 
     @Test
     fun `message joins error and fallback with newline when both present`() {
         val error = DeepSeekError(DeepSeekError.Error(message = "Invalid API key"))
-        val ex = DeepSeekException.from(401, Headers.Empty, error, "Please check your API key.")
+        val ex = DeepSeekException.from(401, DeepSeekHeaders.Empty, error, "Please check your API key.")
         assertEquals("Invalid API key\nPlease check your API key.", ex.message)
     }
 }

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekHeadersTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekHeadersTests.kt
@@ -1,0 +1,86 @@
+package org.oremif.deepseek.errors
+
+import io.ktor.http.HeadersBuilder
+import io.ktor.http.headersOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DeepSeekHeadersTests {
+
+    @Test
+    fun `get returns first value case-insensitively`() {
+        val headers = DeepSeekHeaders(mapOf("Content-Type" to listOf("application/json")))
+        assertEquals("application/json", headers["Content-Type"])
+        assertEquals("application/json", headers["content-type"])
+        assertEquals("application/json", headers["CONTENT-TYPE"])
+    }
+
+    @Test
+    fun `get returns null when header is absent`() {
+        val headers = DeepSeekHeaders(mapOf("X-Request-Id" to listOf("abc")))
+        assertNull(headers["Content-Type"])
+    }
+
+    @Test
+    fun `getAll returns every value for a multi-valued header`() {
+        val headers = DeepSeekHeaders(mapOf("Set-Cookie" to listOf("a=1", "b=2")))
+        assertEquals(listOf("a=1", "b=2"), headers.getAll("set-cookie"))
+    }
+
+    @Test
+    fun `getAll returns empty list when header is absent`() {
+        val headers = DeepSeekHeaders(emptyMap())
+        assertEquals(emptyList(), headers.getAll("Content-Type"))
+    }
+
+    @Test
+    fun `contains is case-insensitive`() {
+        val headers = DeepSeekHeaders(mapOf("Retry-After" to listOf("30")))
+        assertTrue("retry-after" in headers)
+        assertFalse("X-Missing" in headers)
+    }
+
+    @Test
+    fun `Empty reports isEmpty and has no names`() {
+        assertTrue(DeepSeekHeaders.Empty.isEmpty())
+        assertEquals(emptySet(), DeepSeekHeaders.Empty.names())
+    }
+
+    @Test
+    fun `equals and hashCode match when entries match`() {
+        val a = DeepSeekHeaders(mapOf("X-A" to listOf("1")))
+        val b = DeepSeekHeaders(mapOf("X-A" to listOf("1")))
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `toDeepSeekHeaders maps Ktor headers preserving case of first occurrence`() {
+        val ktorHeaders = headersOf(
+            "Content-Type" to listOf("application/json"),
+            "X-Request-Id" to listOf("abc-123"),
+        )
+        val mapped = ktorHeaders.toDeepSeekHeaders()
+        assertEquals("application/json", mapped["content-type"])
+        assertEquals("abc-123", mapped["x-request-id"])
+    }
+
+    @Test
+    fun `toDeepSeekHeaders preserves multi-valued headers`() {
+        val ktorHeaders = HeadersBuilder().apply {
+            append("Set-Cookie", "a=1")
+            append("Set-Cookie", "b=2")
+        }.build()
+        val mapped = ktorHeaders.toDeepSeekHeaders()
+        assertEquals(listOf("a=1", "b=2"), mapped.getAll("Set-Cookie"))
+    }
+
+    @Test
+    fun `toDeepSeekHeaders on empty returns the shared Empty instance`() {
+        val mapped = io.ktor.http.Headers.Empty.toDeepSeekHeaders()
+        assertTrue(mapped === DeepSeekHeaders.Empty)
+    }
+}


### PR DESCRIPTION
## Summary

Addresses finding **2.6** from `findings.md`: `DeepSeekException` leaked `io.ktor.http.Headers` on its public API, forcing users to depend on Ktor and breaking consumers whenever Ktor bumps a major version.

- Introduce `DeepSeekHeaders`: an immutable, Ktor-free wrapper with case-insensitive `get` / `getAll` / `contains`, plus `names`, `isEmpty`, and a shared `Empty` constant.
- Change `DeepSeekException.headers` and both `DeepSeekException.from(...)` overloads — and every subclass constructor — to take `DeepSeekHeaders` instead of `io.ktor.http.Headers`.
- Add an `internal` `Headers.toDeepSeekHeaders()` mapper and use it from the three callers: `validateResponse`, `chatCompletionStream`, `fimCompletionStream`.
- Port existing tests to `DeepSeekHeaders.Empty` and add `DeepSeekHeadersTests` covering case-insensitive lookups, multi-valued headers, equality, and the Ktor mapper (including multi-value preservation and the empty-fast-path).

This is a breaking change for any code that referenced `DeepSeekException.headers` as `io.ktor.http.Headers`, but the shape is the same (`get` / `getAll`) and the new type no longer leaks the HTTP engine into the SDK surface.

## Test plan
- [x] `./gradlew :deepseek-kotlin:build` (all KMP targets compile: JVM, iOS, macOS, Linux, MinGW, wasmJs)
- [x] `./gradlew :deepseek-kotlin:jvmTest` passes, including the new `DeepSeekHeadersTests` and the ported `DeepSeekExceptionTests`
- [x] `iosSimulatorArm64Test`, `macosArm64Test`, `wasmJsTest` all run as part of `build`