### PR TITLE
type DeepSeekError.Error.param as String for OpenAI-compat schema

### DIFF
--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/errors/DeepSeekError.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/errors/DeepSeekError.kt
@@ -1,7 +1,6 @@
 package org.oremif.deepseek.errors
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonObject
 
 @Serializable
 public class DeepSeekError(
@@ -11,7 +10,7 @@ public class DeepSeekError(
     public class Error(
         public val message: String? = null,
         public val type: String? = null,
-        public val param: JsonObject? = null,
+        public val param: String? = null,
         public val code: String? = null,
     ) {
         override fun toString(): String = "Error(message=$message, type=$type, param=$param, code=$code)"

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekExceptionTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekExceptionTests.kt
@@ -1,10 +1,33 @@
 package org.oremif.deepseek.errors
 
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DeepSeekExceptionTests {
+
+    @Test
+    fun `DeepSeekError deserializes string param as String`() {
+        val json = """{"error":{"message":"Invalid value","type":"invalid_request_error","param":"max_tokens","code":"bad_request"}}"""
+        val error = Json.decodeFromString(DeepSeekError.serializer(), json)
+        assertEquals("max_tokens", error.error.param)
+    }
+
+    @Test
+    fun `DeepSeekError deserializes null param as null`() {
+        val json = """{"error":{"message":"Something failed","type":"server_error","param":null,"code":"internal_error"}}"""
+        val error = Json.decodeFromString(DeepSeekError.serializer(), json)
+        assertNull(error.error.param)
+    }
+
+    @Test
+    fun `DeepSeekError deserializes missing param as null`() {
+        val json = """{"error":{"message":"Something failed","type":"server_error","code":"internal_error"}}"""
+        val error = Json.decodeFromString(DeepSeekError.serializer(), json)
+        assertNull(error.error.param)
+    }
 
     @Test
     fun `OverloadServerException exposes 503 as statusCode`() {


### PR DESCRIPTION
## Summary
- `DeepSeekError.Error.param` was declared as `JsonObject?`, but the OpenAI-compatible schema DeepSeek follows returns `param` as a string (the name of the offending parameter, e.g. `"max_tokens"`). A real error response would fail to deserialize.
- Change the field type to `String?` and drop the now-unused `JsonObject` import.
- Addresses finding 2.7 in `findings.md`.

## Test plan
- [x] Added `DeepSeekError deserializes string param as String` — parses `"param":"max_tokens"` and asserts the value.
- [x] Added `DeepSeekError deserializes null param as null` — parses `"param":null`.
- [x] Added `DeepSeekError deserializes missing param as null` — parses a payload without the `param` key.
- [x] `./gradlew :deepseek-kotlin:jvmTest` passes locally.