### PR TITLE
fix illegal comma in ChatCompletionTests test name

### DIFF
--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/models/chatCompletions.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/models/chatCompletions.kt
@@ -134,7 +134,7 @@ class ChatCompletionTests {
     }
 
     @Test
-    fun `streaming delta tool_calls first chunk parses with id, name and empty arguments`() {
+    fun `streaming delta tool_calls first chunk parses with id and name and empty arguments`() {
         val json = """
             {
                 "id": "chunk-1",


### PR DESCRIPTION
## Summary
- `ChatCompletionTests.streaming delta tool_calls first chunk parses with id, name and empty arguments` contained a `,` in its backticked name, which the JVM target rejects as an illegal method identifier.
- Replaced the comma with `and` so the identifier is valid on all targets.

## Test plan
- [x] `./gradlew :deepseek-kotlin:jvmTest`