### PR TITLE
fix SCM developerConnection SSH URL separator

### DIFF
--- a/deepseek-kotlin/build.gradle.kts
+++ b/deepseek-kotlin/build.gradle.kts
@@ -172,7 +172,7 @@ mavenPublishing {
         scm {
             url = "https://github.com/Oremif/deepseek-kotlin"
             connection = "scm:git:git://github.com/Oremif/deepseek-kotlin.git"
-            developerConnection = "scm:git:git@github.com/Oremif/deepseek-kotlin.git"
+            developerConnection = "scm:git:git@github.com:Oremif/deepseek-kotlin.git"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace `/` with `:` in the SSH-form `developerConnection` URL in `deepseek-kotlin/build.gradle.kts` so POM consumers can clone via the developer connection.

Before:
```
scm:git:git@github.com/Oremif/deepseek-kotlin.git
```

After:
```
scm:git:git@github.com:Oremif/deepseek-kotlin.git
```

Addresses item 4.2 from `findings.md`.

## Test plan
- [ ] `./gradlew :deepseek-kotlin:generatePomFileForKotlinMultiplatformPublication` and verify the `<developerConnection>` element in the generated POM uses `git@github.com:Oremif/...`.
- [ ] Sanity-check: `git clone scm:git:git@github.com:Oremif/deepseek-kotlin.git` (stripping the `scm:git:` prefix) resolves to a valid SSH remote.