### PR TITLE
ci: add JVM build & test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: Build & Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+permissions:
+  contents: read
+
+env:
+  JAVA_VERSION: 21
+  JAVA_DISTRIBUTION: temurin
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      checks: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          validate-wrappers: true
+          add-job-summary: always
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
+
+      - name: Run tests
+        run: ./gradlew jvmTest --continue --parallel
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results
+          path: '**/build/test-results/**/TEST-*.xml'
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v6
+        if: always()
+        with:
+          report_paths: '**/build/test-results/**/TEST-*.xml'


### PR DESCRIPTION
## Summary
- addresses finding 4.3 from `findings.md` — no CI existed beyond `publish.yml`
- new `.github/workflows/ci.yml` runs `./gradlew jvmTest` on every PR and push to `master`, plus `workflow_dispatch`
- Ubuntu-only, JVM-only on purpose: multiplatform targets (iOS/wasm/Android) are skipped to keep GitHub Actions runner minutes low
- concurrency group cancels in-flight PR runs, keeps master runs; wrapper is validated; test-result XMLs are uploaded and JUnit report is published on every run

## What's intentionally out of scope
- `apiCheck` — `binary-compatibility-validator` is not configured yet (finding 4.4); once it's added, wire it into this workflow
- macOS/Windows runners and iOS/wasm/Android tests — skipped to avoid paid minutes

## Test plan
- [ ] CI run on this PR is green
- [ ] re-running via `workflow_dispatch` on master succeeds
- [ ] a failing test surfaces in the "Publish Test Report" step