### PR TITLE
Expand test coverage and migrate to kotest assertions

### DIFF
--- a/deepseek-kotlin/build.gradle.kts
+++ b/deepseek-kotlin/build.gradle.kts
@@ -84,6 +84,7 @@ kotlin {
                 implementation(libs.kotlin.test)
                 implementation(libs.coroutines.test)
                 implementation(libs.ktor.client.mock)
+                implementation(libs.kotest.assertions.core)
             }
         }
 

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/ChatCompletionApiTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/ChatCompletionApiTests.kt
@@ -1,0 +1,159 @@
+package org.oremif.deepseek.api
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldEndWith
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.oremif.deepseek.errors.DeepSeekException
+import org.oremif.deepseek.models.ChatModel
+import org.oremif.deepseek.models.FinishReason
+import org.oremif.deepseek.models.UserMessage
+import org.oremif.deepseek.testing.mockEngine
+import org.oremif.deepseek.testing.testClient
+import kotlin.test.Test
+
+class ChatCompletionApiTests {
+
+    private val successBody = """
+        {
+            "id": "abc-123",
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "index": 0,
+                    "message": {
+                        "content": "Hello!",
+                        "role": "assistant"
+                    }
+                }
+            ],
+            "created": 1705651092,
+            "model": "deepseek-chat",
+            "object": "chat.completion",
+            "usage": {
+                "completion_tokens": 3,
+                "prompt_tokens": 8,
+                "total_tokens": 11
+            }
+        }
+    """.trimIndent()
+
+    @Test
+    fun `chat posts to chat completions endpoint with JSON body`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+        var capturedBody: String? = null
+        val engine = mockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            capturedBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = successBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        client.chat("Hi")
+
+        capturedMethod shouldBe HttpMethod.Post
+        capturedPath.shouldNotBeNull().shouldEndWith("/chat/completions")
+        val body = capturedBody.shouldNotBeNull()
+        body shouldContain "\"model\":\"deepseek-chat\""
+        body shouldContain "\"content\":\"Hi\""
+    }
+
+    @Test
+    fun `chat parses a successful response`() = runTest {
+        val engine = mockEngine {
+            respond(
+                content = successBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        val response = client.chat(listOf(UserMessage("Hi")))
+
+        response.id shouldBe "abc-123"
+        response.model shouldBe "deepseek-chat"
+        response.choices shouldHaveSize 1
+        response.choices[0].finishReason shouldBe FinishReason.STOP
+        response.choices[0].message.content shouldBe "Hello!"
+        response.usage.shouldNotBeNull().totalTokens shouldBe 11
+    }
+
+    @Test
+    fun `chat maps 401 to UnauthorizedException with parsed error`() = runTest {
+        val engine = mockEngine {
+            respond(
+                content = """{"error":{"message":"Invalid API key","type":"authentication_error"}}""",
+                status = HttpStatusCode.Unauthorized,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        val ex = shouldThrow<DeepSeekException.UnauthorizedException> {
+            client.chat("Hi")
+        }
+        ex.statusCode shouldBe 401
+        ex.error?.error?.message shouldBe "Invalid API key"
+    }
+
+    @Test
+    fun `chat maps 503 to OverloadServerException`() = runTest {
+        val engine = mockEngine {
+            respond(
+                content = """{"error":{"message":"overloaded"}}""",
+                status = HttpStatusCode.ServiceUnavailable,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        val ex = shouldThrow<DeepSeekException.OverloadServerException> {
+            client.chat("Hi")
+        }
+        ex.statusCode shouldBe 503
+    }
+
+    @Test
+    fun `chatCompletion DSL builder sends messages and model`() = runTest {
+        var capturedBody: String? = null
+        val engine = mockEngine { request ->
+            capturedBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = successBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        client.chatCompletion {
+            params { model = ChatModel.DEEPSEEK_REASONER }
+            messages {
+                system("You are helpful")
+                user("Hi")
+            }
+        }
+
+        val body = capturedBody.shouldNotBeNull()
+        body shouldContain "\"model\":\"deepseek-reasoner\""
+        body shouldContain "\"role\":\"system\""
+        body shouldContain "\"role\":\"user\""
+    }
+}

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/ChatCompletionStreamApiTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/ChatCompletionStreamApiTests.kt
@@ -1,0 +1,139 @@
+package org.oremif.deepseek.api
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.oremif.deepseek.models.ChatCompletionRequest
+import org.oremif.deepseek.models.ChatModel
+import org.oremif.deepseek.models.FinishReason
+import org.oremif.deepseek.models.StreamOptions
+import org.oremif.deepseek.models.UserMessage
+import org.oremif.deepseek.models.chatCompletionStreamParams
+import org.oremif.deepseek.testing.sseMockEngine
+import org.oremif.deepseek.testing.testStreamClient
+import kotlin.test.Test
+
+class ChatCompletionStreamApiTests {
+
+    private val request = ChatCompletionRequest(
+        messages = listOf(UserMessage("Hi")),
+        model = ChatModel.DEEPSEEK_CHAT,
+        stream = true,
+    )
+
+    private fun sseBody(vararg events: String): String =
+        events.joinToString(separator = "") { "data: $it\n\n" }
+
+    @Test
+    fun `chat stream delivers chunks and ignores DONE marker`() = runTest {
+        val chunks = arrayOf(
+            """{"id":"c1","choices":[{"delta":{"role":"assistant","content":""},"index":0,"finish_reason":null}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk"}""",
+            """{"id":"c1","choices":[{"delta":{"content":"Hello"},"index":0,"finish_reason":null}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk"}""",
+            """{"id":"c1","choices":[{"delta":{"content":"!"},"index":0,"finish_reason":"stop"}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk"}""",
+            "[DONE]",
+        )
+        val engine = sseMockEngine {
+            respond(
+                content = sseBody(*chunks),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.EventStream.toString()),
+            )
+        }
+        val client = testStreamClient(engine)
+
+        val received = client.chatCompletionStream(request).toList()
+
+        received shouldHaveSize 3
+        received[0].choices[0].delta.role shouldBe "assistant"
+        received[1].choices[0].delta.content shouldBe "Hello"
+        received[2].choices[0].delta.content shouldBe "!"
+        received[2].choices[0].finishReason shouldBe FinishReason.STOP
+    }
+
+    @Test
+    fun `chat stream with include_usage yields final usage-only chunk before DONE`() = runTest {
+        val chunks = arrayOf(
+            """{"id":"c1","choices":[{"delta":{"content":"Hi"},"index":0,"finish_reason":null}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk"}""",
+            """{"id":"c1","choices":[{"delta":{},"index":0,"finish_reason":"stop"}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk"}""",
+            """{"id":"c1","choices":[],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk","usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}""",
+            "[DONE]",
+        )
+        val engine = sseMockEngine {
+            respond(
+                content = sseBody(*chunks),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.EventStream.toString()),
+            )
+        }
+        val client = testStreamClient(engine)
+
+        val received = client.chat(
+            chatCompletionStreamParams {
+                streamOptions = StreamOptions(includeUsage = true)
+            },
+            listOf(UserMessage("Hi")),
+        ).toList()
+
+        received shouldHaveSize 3
+        val last = received.last()
+        last.choices.shouldBeEmpty()
+        val usage = last.usage.shouldNotBeNull()
+        usage.promptTokens shouldBe 3
+        usage.completionTokens shouldBe 2
+        usage.totalTokens shouldBe 5
+    }
+
+    @Test
+    fun `chat stream flow completes without items when server sends only DONE`() = runTest {
+        val engine = sseMockEngine {
+            respond(
+                content = sseBody("[DONE]"),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.EventStream.toString()),
+            )
+        }
+        val client = testStreamClient(engine)
+
+        val received = client.chatCompletionStream(request).toList()
+
+        received.shouldBeEmpty()
+    }
+
+    @Test
+    fun `chat stream preserves tool_calls delta fields`() = runTest {
+        val chunks = arrayOf(
+            """{"id":"c1","choices":[{"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"sum","arguments":""}}]},"index":0,"finish_reason":null}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk"}""",
+            """{"id":"c1","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"a\":1,\"b\":2}"}}]},"index":0,"finish_reason":null}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk"}""",
+            """{"id":"c1","choices":[{"delta":{},"index":0,"finish_reason":"tool_calls"}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk"}""",
+            "[DONE]",
+        )
+        val engine = sseMockEngine {
+            respond(
+                content = sseBody(*chunks),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.EventStream.toString()),
+            )
+        }
+        val client = testStreamClient(engine)
+
+        val received = client.chatCompletionStream(request).toList()
+
+        received shouldHaveSize 3
+        val first = received[0].choices[0].delta.toolCalls.shouldNotBeNull().single()
+        first.id shouldBe "call_1"
+        first.function?.name shouldBe "sum"
+        val second = received[1].choices[0].delta.toolCalls.shouldNotBeNull().single()
+        second.function?.arguments shouldBe """{"a":1,"b":2}"""
+        received[2].choices[0].finishReason shouldBe FinishReason.TOOL_CALLS
+        received[2].choices[0].delta.toolCalls.shouldBeNull()
+    }
+}

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/EndpointApiTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/EndpointApiTests.kt
@@ -1,0 +1,93 @@
+package org.oremif.deepseek.api
+
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldEndWith
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.oremif.deepseek.models.CurrencyType
+import org.oremif.deepseek.testing.mockEngine
+import org.oremif.deepseek.testing.testClient
+import kotlin.test.Test
+
+class EndpointApiTests {
+
+    @Test
+    fun `userBalance GETs the balance endpoint and parses the payload`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+        val engine = mockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = """
+                    {
+                        "is_available": true,
+                        "balance_infos": [
+                            {
+                                "currency": "USD",
+                                "total_balance": "10.00",
+                                "granted_balance": "5.00",
+                                "topped_up_balance": "5.00"
+                            }
+                        ]
+                    }
+                """.trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        val balance = client.userBalance()
+
+        capturedMethod shouldBe HttpMethod.Get
+        capturedPath.shouldNotBeNull().shouldEndWith("/user/balance")
+        balance.isAvailable.shouldBeTrue()
+        balance.balanceInfos shouldHaveSize 1
+        val info = balance.balanceInfos[0]
+        info.currency shouldBe CurrencyType.USD
+        info.totalBalance shouldBe "10.00"
+        info.grantedBalance shouldBe "5.00"
+        info.toppedUpBalance shouldBe "5.00"
+    }
+
+    @Test
+    fun `models GETs the models endpoint and parses the list`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+        val engine = mockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            respond(
+                content = """
+                    {
+                        "object": "list",
+                        "data": [
+                            {"id": "deepseek-chat", "object": "model", "owned_by": "deepseek"},
+                            {"id": "deepseek-reasoner", "object": "model", "owned_by": "deepseek"}
+                        ]
+                    }
+                """.trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        val models = client.models()
+
+        capturedMethod shouldBe HttpMethod.Get
+        capturedPath.shouldNotBeNull().shouldEndWith("/models")
+        models.`object` shouldBe "list"
+        models.data shouldHaveSize 2
+        models.data.map { it.id } shouldBe listOf("deepseek-chat", "deepseek-reasoner")
+    }
+}

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/FIMCompletionApiTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/FIMCompletionApiTests.kt
@@ -1,0 +1,137 @@
+package org.oremif.deepseek.api
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldEndWith
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.oremif.deepseek.errors.DeepSeekException
+import org.oremif.deepseek.models.FinishReason
+import org.oremif.deepseek.models.fimCompletionParams
+import org.oremif.deepseek.testing.mockEngine
+import org.oremif.deepseek.testing.testClient
+import kotlin.test.Test
+
+class FIMCompletionApiTests {
+
+    private val successBody = """
+        {
+            "id": "fim-1",
+            "choices": [
+                {
+                    "text": "    return a + b\n",
+                    "index": 0,
+                    "finish_reason": "stop"
+                }
+            ],
+            "created": 1705651092,
+            "model": "deepseek-chat",
+            "object": "text_completion",
+            "usage": {
+                "completion_tokens": 5,
+                "prompt_tokens": 7,
+                "total_tokens": 12
+            }
+        }
+    """.trimIndent()
+
+    @Test
+    fun `fim posts to beta completions endpoint with prompt in body`() = runTest {
+        var capturedMethod: HttpMethod? = null
+        var capturedPath: String? = null
+        var capturedBody: String? = null
+        val engine = mockEngine { request ->
+            capturedMethod = request.method
+            capturedPath = request.url.encodedPath
+            capturedBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = successBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        client.fim("def add(a, b):")
+
+        capturedMethod shouldBe HttpMethod.Post
+        capturedPath.shouldNotBeNull().shouldEndWith("/beta/completions")
+        val body = capturedBody.shouldNotBeNull()
+        body shouldContain "\"prompt\":\"def add(a, b):\""
+        body shouldContain "\"model\":\"deepseek-chat\""
+    }
+
+    @Test
+    fun `fim parses a successful response`() = runTest {
+        val engine = mockEngine {
+            respond(
+                content = successBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        val response = client.fim("def add(a, b):")
+
+        response.id shouldBe "fim-1"
+        response.`object` shouldBe "text_completion"
+        response.choices shouldHaveSize 1
+        response.choices[0].text shouldBe "    return a + b\n"
+        response.choices[0].finishReason shouldBe FinishReason.STOP
+        response.usage.shouldNotBeNull().totalTokens shouldBe 12
+    }
+
+    @Test
+    fun `fim sends suffix when provided via params`() = runTest {
+        var capturedBody: String? = null
+        val engine = mockEngine { request ->
+            capturedBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = successBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        client.fim(
+            fimCompletionParams {
+                suffix = "\n# end"
+                maxTokens = 64
+            },
+            "def add(a, b):",
+        )
+
+        val body = capturedBody.shouldNotBeNull()
+        body shouldContain "\"suffix\":\"\\n# end\""
+        body shouldContain "\"max_tokens\":64"
+    }
+
+    @Test
+    fun `fim maps 402 to InsufficientBalanceException`() = runTest {
+        val engine = mockEngine {
+            respond(
+                content = """{"error":{"message":"Insufficient Balance","type":"insufficient_balance_error"}}""",
+                status = HttpStatusCode.PaymentRequired,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = testClient(engine)
+
+        val ex = shouldThrow<DeepSeekException.InsufficientBalanceException> {
+            client.fim("def foo():")
+        }
+        ex.statusCode shouldBe 402
+        ex.error?.error?.message shouldBe "Insufficient Balance"
+    }
+}

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/StreamErrorTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/api/StreamErrorTests.kt
@@ -1,62 +1,27 @@
 package org.oremif.deepseek.api
 
-import io.ktor.client.*
-import io.ktor.client.engine.*
-import io.ktor.client.engine.mock.*
-import io.ktor.client.plugins.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.plugins.sse.*
-import io.ktor.client.request.*
-import io.ktor.http.*
-import io.ktor.serialization.kotlinx.json.*
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldNotBeInstanceOf
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonNamingStrategy
-import org.oremif.deepseek.client.DeepSeekClientStream
 import org.oremif.deepseek.errors.DeepSeekException
 import org.oremif.deepseek.models.ChatCompletionRequest
 import org.oremif.deepseek.models.ChatModel
 import org.oremif.deepseek.models.FIMCompletionRequest
 import org.oremif.deepseek.models.UserMessage
+import org.oremif.deepseek.testing.sseMockEngine
+import org.oremif.deepseek.testing.testStreamClient
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
-
-private class SseMockEngine(config: MockEngineConfig) : MockEngine(config) {
-    override val supportedCapabilities: Set<HttpClientEngineCapability<out Any>> =
-        super.supportedCapabilities + SSECapability
-}
-
-private fun sseMockEngine(handler: MockRequestHandler): SseMockEngine =
-    SseMockEngine(MockEngineConfig().apply { requestHandlers.add(handler) })
 
 class StreamErrorTests {
-
-    @OptIn(ExperimentalSerializationApi::class)
-    private val jsonConfig = Json {
-        ignoreUnknownKeys = true
-        namingStrategy = JsonNamingStrategy.SnakeCase
-    }
-
-    private fun streamClient(engine: HttpClientEngine): DeepSeekClientStream {
-        val http = HttpClient(engine) {
-            install(ContentNegotiation) { json(jsonConfig) }
-            install(SSE)
-            defaultRequest {
-                url("https://api.deepseek.com")
-                contentType(ContentType.Application.Json)
-            }
-        }
-        return DeepSeekClientStream {
-            jsonConfig(jsonConfig)
-            httpClient(http)
-        }
-    }
 
     private val chatRequest = ChatCompletionRequest(
         messages = listOf(UserMessage("Hi")),
@@ -79,15 +44,15 @@ class StreamErrorTests {
                 headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             )
         }
-        val client = streamClient(engine)
-        val ex = assertFailsWith<DeepSeekException.BadRequestException> {
+        val client = testStreamClient(engine)
+        val ex = shouldThrow<DeepSeekException.BadRequestException> {
             client.chatCompletionStream(chatRequest).toList()
         }
-        assertEquals(400, ex.statusCode)
-        val error = assertNotNull(ex.error, "error body should be parsed")
-        assertEquals("Invalid model", error.error.message)
-        assertEquals("invalid_request_error", error.error.type)
-        assertEquals("model_not_found", error.error.code)
+        ex.statusCode shouldBe 400
+        val error = ex.error.shouldNotBeNull()
+        error.error.message shouldBe "Invalid model"
+        error.error.type shouldBe "invalid_request_error"
+        error.error.code shouldBe "model_not_found"
     }
 
     @Test
@@ -99,12 +64,12 @@ class StreamErrorTests {
                 headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             )
         }
-        val client = streamClient(engine)
-        val ex = assertFailsWith<DeepSeekException.UnauthorizedException> {
+        val client = testStreamClient(engine)
+        val ex = shouldThrow<DeepSeekException.UnauthorizedException> {
             client.chatCompletionStream(chatRequest).toList()
         }
-        assertEquals(401, ex.statusCode)
-        assertEquals("Invalid API key", ex.error?.error?.message)
+        ex.statusCode shouldBe 401
+        ex.error?.error?.message shouldBe "Invalid API key"
     }
 
     @Test
@@ -116,12 +81,12 @@ class StreamErrorTests {
                 headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             )
         }
-        val client = streamClient(engine)
-        val ex = assertFailsWith<DeepSeekException.OverloadServerException> {
+        val client = testStreamClient(engine)
+        val ex = shouldThrow<DeepSeekException.OverloadServerException> {
             client.chatCompletionStream(chatRequest).toList()
         }
-        assertEquals(503, ex.statusCode)
-        assertEquals("Server overloaded", ex.error?.error?.message)
+        ex.statusCode shouldBe 503
+        ex.error?.error?.message shouldBe "Server overloaded"
     }
 
     @Test
@@ -133,12 +98,12 @@ class StreamErrorTests {
                 headers = headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString())
             )
         }
-        val client = streamClient(engine)
-        val ex = assertFailsWith<DeepSeekException.InternalServerException> {
+        val client = testStreamClient(engine)
+        val ex = shouldThrow<DeepSeekException.InternalServerException> {
             client.chatCompletionStream(chatRequest).toList()
         }
-        assertEquals(500, ex.statusCode)
-        assertNull(ex.error, "unparsable body must not crash — error should be null")
+        ex.statusCode shouldBe 500
+        ex.error.shouldBeNull()
     }
 
     @Test
@@ -146,14 +111,11 @@ class StreamErrorTests {
         val engine = sseMockEngine {
             throw RuntimeException("Network unreachable")
         }
-        val client = streamClient(engine)
-        val thrown = assertFailsWith<Throwable> {
+        val client = testStreamClient(engine)
+        val thrown = shouldThrow<Throwable> {
             client.chatCompletionStream(chatRequest).toList()
         }
-        assertTrue(
-            thrown !is DeepSeekException,
-            "network error must not be wrapped as DeepSeekException when no HTTP response is available"
-        )
+        thrown.shouldNotBeInstanceOf<DeepSeekException>()
     }
 
     @Test
@@ -165,12 +127,12 @@ class StreamErrorTests {
                 headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             )
         }
-        val client = streamClient(engine)
-        val ex = assertFailsWith<DeepSeekException.BadRequestException> {
+        val client = testStreamClient(engine)
+        val ex = shouldThrow<DeepSeekException.BadRequestException> {
             client.fimCompletionStream(fimRequest).toList()
         }
-        assertEquals(400, ex.statusCode)
-        assertEquals("Bad FIM prompt", ex.error?.error?.message)
+        ex.statusCode shouldBe 400
+        ex.error?.error?.message shouldBe "Bad FIM prompt"
     }
 
     @Test
@@ -178,13 +140,10 @@ class StreamErrorTests {
         val engine = sseMockEngine {
             throw RuntimeException("Network unreachable")
         }
-        val client = streamClient(engine)
-        val thrown = assertFailsWith<Throwable> {
+        val client = testStreamClient(engine)
+        val thrown = shouldThrow<Throwable> {
             client.fimCompletionStream(fimRequest).toList()
         }
-        assertTrue(
-            thrown !is DeepSeekException,
-            "network error must not be wrapped as DeepSeekException when no HTTP response is available"
-        )
+        thrown.shouldNotBeInstanceOf<DeepSeekException>()
     }
 }

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/client/DeepSeekClientBuilderTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/client/DeepSeekClientBuilderTests.kt
@@ -1,5 +1,10 @@
 package org.oremif.deepseek.client
 
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpTimeout
@@ -12,12 +17,6 @@ import io.ktor.client.plugins.sse.SSE
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertSame
-import kotlin.test.assertTrue
 
 private inline fun <T : DeepSeekClientBase, R> T.use(block: (T) -> R): R =
     try {
@@ -34,16 +33,10 @@ class DeepSeekClientBuilderTests {
             httpClient { /* additive configuration — intentionally empty */ }
         }.use { client ->
             val http = client.client
-            assertNotNull(http.pluginOrNull(Auth), "Auth must survive httpClient { }")
-            assertNotNull(
-                http.pluginOrNull(ContentNegotiation),
-                "ContentNegotiation must survive httpClient { }"
-            )
-            assertNotNull(
-                http.pluginOrNull(HttpRequestRetry),
-                "HttpRequestRetry must survive httpClient { }"
-            )
-            assertNotNull(http.pluginOrNull(HttpTimeout), "HttpTimeout must survive httpClient { }")
+            http.pluginOrNull(Auth).shouldNotBeNull()
+            http.pluginOrNull(ContentNegotiation).shouldNotBeNull()
+            http.pluginOrNull(HttpRequestRetry).shouldNotBeNull()
+            http.pluginOrNull(HttpTimeout).shouldNotBeNull()
         }
     }
 
@@ -53,30 +46,18 @@ class DeepSeekClientBuilderTests {
             httpClient { /* additive configuration — intentionally empty */ }
         }.use { client ->
             val http = client.client
-            assertNotNull(http.pluginOrNull(SSE), "SSE must survive httpClient { } on stream client")
-            assertNotNull(http.pluginOrNull(Auth), "Auth must survive on stream client")
-            assertNotNull(
-                http.pluginOrNull(ContentNegotiation),
-                "ContentNegotiation must survive on stream client"
-            )
-            assertNotNull(
-                http.pluginOrNull(HttpRequestRetry),
-                "HttpRequestRetry must survive on stream client"
-            )
-            assertNotNull(
-                http.pluginOrNull(HttpTimeout),
-                "HttpTimeout must survive on stream client"
-            )
+            http.pluginOrNull(SSE).shouldNotBeNull()
+            http.pluginOrNull(Auth).shouldNotBeNull()
+            http.pluginOrNull(ContentNegotiation).shouldNotBeNull()
+            http.pluginOrNull(HttpRequestRetry).shouldNotBeNull()
+            http.pluginOrNull(HttpTimeout).shouldNotBeNull()
         }
     }
 
     @Test
     fun `logging is not installed by default`() {
         DeepSeekClient("test-token").use { client ->
-            assertNull(
-                client.client.pluginOrNull(Logging),
-                "Logging plugin must be opt-in — nothing should be logged by default"
-            )
+            client.client.pluginOrNull(Logging).shouldBeNull()
         }
     }
 
@@ -85,10 +66,7 @@ class DeepSeekClientBuilderTests {
         DeepSeekClient("test-token") {
             logging { level = LogLevel.BODY }
         }.use { client ->
-            assertNotNull(
-                client.client.pluginOrNull(Logging),
-                "logging { } must install the Logging plugin"
-            )
+            client.client.pluginOrNull(Logging).shouldNotBeNull()
         }
     }
 
@@ -97,10 +75,7 @@ class DeepSeekClientBuilderTests {
         DeepSeekClient("test-token") {
             logging()
         }.use { client ->
-            assertNotNull(
-                client.client.pluginOrNull(Logging),
-                "logging() with no block must still install the plugin"
-            )
+            client.client.pluginOrNull(Logging).shouldNotBeNull()
         }
     }
 
@@ -110,20 +85,13 @@ class DeepSeekClientBuilderTests {
             logging { level = LogLevel.HEADERS }
             httpClient { /* additive configuration — intentionally empty */ }
         }.use { client ->
-            assertNotNull(
-                client.client.pluginOrNull(Logging),
-                "Logging from logging { } must survive layered httpClient { } on stream client"
-            )
-            assertNotNull(
-                client.client.pluginOrNull(SSE),
-                "SSE must survive alongside logging { } on stream client"
-            )
+            client.client.pluginOrNull(Logging).shouldNotBeNull()
+            client.client.pluginOrNull(SSE).shouldNotBeNull()
         }
     }
 
     @Test
     fun `logging block can be called multiple times and accumulates sanitizers`() {
-        var calls = 0
         DeepSeekClient("test-token") {
             logging { level = LogLevel.BODY }
             logging {
@@ -131,10 +99,8 @@ class DeepSeekClientBuilderTests {
                 sanitizeHeader { header -> header == "X-Trace-Id" }
             }
         }.use { client ->
-            calls++
-            assertNotNull(client.client.pluginOrNull(Logging))
+            client.client.pluginOrNull(Logging).shouldNotBeNull()
         }
-        assertEquals(1, calls)
     }
 
     @Test
@@ -143,10 +109,7 @@ class DeepSeekClientBuilderTests {
         DeepSeekClient("test-token") {
             httpClient(replacement)
         }.use { client ->
-            assertNull(
-                client.client.pluginOrNull(Auth),
-                "Replacement overload must not silently re-add Auth"
-            )
+            client.client.pluginOrNull(Auth).shouldBeNull()
         }
     }
 
@@ -160,9 +123,9 @@ class DeepSeekClientBuilderTests {
             }
         }.use { client ->
             val cfg = client.config.jsonConfig.configuration
-            assertFalse(cfg.prettyPrint, "prettyPrint must reflect user setting")
-            assertFalse(cfg.ignoreUnknownKeys, "ignoreUnknownKeys must reflect user setting")
-            assertFalse(cfg.isLenient, "isLenient must reflect user setting")
+            cfg.prettyPrint.shouldBeFalse()
+            cfg.ignoreUnknownKeys.shouldBeFalse()
+            cfg.isLenient.shouldBeFalse()
         }
     }
 
@@ -175,9 +138,9 @@ class DeepSeekClientBuilderTests {
             }
         }.use { client ->
             val cfg = client.config.jsonConfig.configuration
-            assertFalse(cfg.prettyPrint, "prettyPrint must be flipped")
-            assertTrue(cfg.ignoreUnknownKeys, "ignoreUnknownKeys default must survive")
-            assertNotNull(cfg.namingStrategy, "SnakeCase namingStrategy default must survive")
+            cfg.prettyPrint.shouldBeFalse()
+            cfg.ignoreUnknownKeys.shouldBeTrue()
+            cfg.namingStrategy.shouldNotBeNull()
         }
     }
 
@@ -190,10 +153,7 @@ class DeepSeekClientBuilderTests {
         DeepSeekClient("test-token") {
             jsonConfig(custom)
         }.use { client ->
-            assertSame(
-                custom, client.config.jsonConfig,
-                "Json overload must store the exact instance provided"
-            )
+            client.config.jsonConfig shouldBeSameInstanceAs custom
         }
     }
 
@@ -204,18 +164,9 @@ class DeepSeekClientBuilderTests {
                 prettyPrint = false
             }
         }.use { client ->
-            assertFalse(
-                client.config.jsonConfig.configuration.prettyPrint,
-                "Stream client must honour jsonConfig { } block"
-            )
-            assertNotNull(
-                client.client.pluginOrNull(SSE),
-                "SSE must survive with custom jsonConfig on stream client"
-            )
-            assertNotNull(
-                client.client.pluginOrNull(ContentNegotiation),
-                "ContentNegotiation must be installed with custom jsonConfig on stream client"
-            )
+            client.config.jsonConfig.configuration.prettyPrint.shouldBeFalse()
+            client.client.pluginOrNull(SSE).shouldNotBeNull()
+            client.client.pluginOrNull(ContentNegotiation).shouldNotBeNull()
         }
     }
 }

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/client/DeepSeekClientLifecycleTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/client/DeepSeekClientLifecycleTests.kt
@@ -1,9 +1,9 @@
 package org.oremif.deepseek.client
 
+import io.kotest.matchers.booleans.shouldBeTrue
 import kotlinx.coroutines.job
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class DeepSeekClientLifecycleTests {
 
@@ -12,7 +12,7 @@ class DeepSeekClientLifecycleTests {
         val client = DeepSeekClient("test-token")
         val job = client.client.coroutineContext.job
         client.closeAndJoin()
-        assertTrue(job.isCompleted, "Client coroutine scope must complete after closeAndJoin")
+        job.isCompleted.shouldBeTrue()
     }
 
     @Test
@@ -20,9 +20,6 @@ class DeepSeekClientLifecycleTests {
         val client = DeepSeekClientStream("test-token")
         val job = client.client.coroutineContext.job
         client.closeAndJoin()
-        assertTrue(
-            job.isCompleted,
-            "Stream client coroutine scope must complete after closeAndJoin"
-        )
+        job.isCompleted.shouldBeTrue()
     }
 }

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekExceptionTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekExceptionTests.kt
@@ -1,10 +1,10 @@
 package org.oremif.deepseek.errors
 
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class DeepSeekExceptionTests {
 
@@ -12,69 +12,66 @@ class DeepSeekExceptionTests {
     fun `DeepSeekError deserializes string param as String`() {
         val json = """{"error":{"message":"Invalid value","type":"invalid_request_error","param":"max_tokens","code":"bad_request"}}"""
         val error = Json.decodeFromString(DeepSeekError.serializer(), json)
-        assertEquals("max_tokens", error.error.param)
+        error.error.param shouldBe "max_tokens"
     }
 
     @Test
     fun `DeepSeekError deserializes null param as null`() {
         val json = """{"error":{"message":"Something failed","type":"server_error","param":null,"code":"internal_error"}}"""
         val error = Json.decodeFromString(DeepSeekError.serializer(), json)
-        assertNull(error.error.param)
+        error.error.param.shouldBeNull()
     }
 
     @Test
     fun `DeepSeekError deserializes missing param as null`() {
         val json = """{"error":{"message":"Something failed","type":"server_error","code":"internal_error"}}"""
         val error = Json.decodeFromString(DeepSeekError.serializer(), json)
-        assertNull(error.error.param)
+        error.error.param.shouldBeNull()
     }
 
     @Test
     fun `OverloadServerException exposes 503 as statusCode`() {
         val ex = DeepSeekException.OverloadServerException(DeepSeekHeaders.Empty, null, "overloaded")
-        assertEquals(503, ex.statusCode)
+        ex.statusCode shouldBe 503
     }
 
     @Test
     fun `from with 4 args maps 503 to OverloadServerException`() {
         val ex = DeepSeekException.from(503, DeepSeekHeaders.Empty, null, "Service Unavailable")
-        assertTrue(
-            ex is DeepSeekException.OverloadServerException,
-            "expected OverloadServerException, got ${ex::class.simpleName}"
-        )
-        assertEquals(503, ex.statusCode)
+        ex.shouldBeInstanceOf<DeepSeekException.OverloadServerException>()
+        ex.statusCode shouldBe 503
     }
 
     @Test
     fun `both from overloads return OverloadServerException for 503`() {
         val fromShort = DeepSeekException.from(503, DeepSeekHeaders.Empty, null)
         val fromLong = DeepSeekException.from(503, DeepSeekHeaders.Empty, null, "Service Unavailable")
-        assertEquals(fromShort::class, fromLong::class)
+        fromShort::class shouldBe fromLong::class
     }
 
     @Test
     fun `message has no leading newline when error is null`() {
         val ex = DeepSeekException.from(401, DeepSeekHeaders.Empty, null, "Please check your API key.")
-        assertEquals("Please check your API key.", ex.message)
+        ex.message shouldBe "Please check your API key."
     }
 
     @Test
     fun `message is empty when both error and fallback message are absent`() {
         val ex = DeepSeekException.UnexpectedStatusCodeException(418, DeepSeekHeaders.Empty, null, null)
-        assertEquals("", ex.message)
+        ex.message shouldBe ""
     }
 
     @Test
     fun `message contains only error message when fallback message is null`() {
         val error = DeepSeekError(DeepSeekError.Error(message = "Invalid API key"))
         val ex = DeepSeekException.UnexpectedStatusCodeException(418, DeepSeekHeaders.Empty, error, null)
-        assertEquals("Invalid API key", ex.message)
+        ex.message shouldBe "Invalid API key"
     }
 
     @Test
     fun `message joins error and fallback with newline when both present`() {
         val error = DeepSeekError(DeepSeekError.Error(message = "Invalid API key"))
         val ex = DeepSeekException.from(401, DeepSeekHeaders.Empty, error, "Please check your API key.")
-        assertEquals("Invalid API key\nPlease check your API key.", ex.message)
+        ex.message shouldBe "Invalid API key\nPlease check your API key."
     }
 }

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekHeadersTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/errors/DeepSeekHeadersTests.kt
@@ -1,60 +1,61 @@
 package org.oremif.deepseek.errors
 
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.ktor.http.HeadersBuilder
 import io.ktor.http.headersOf
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class DeepSeekHeadersTests {
 
     @Test
     fun `get returns first value case-insensitively`() {
         val headers = DeepSeekHeaders(mapOf("Content-Type" to listOf("application/json")))
-        assertEquals("application/json", headers["Content-Type"])
-        assertEquals("application/json", headers["content-type"])
-        assertEquals("application/json", headers["CONTENT-TYPE"])
+        headers["Content-Type"] shouldBe "application/json"
+        headers["content-type"] shouldBe "application/json"
+        headers["CONTENT-TYPE"] shouldBe "application/json"
     }
 
     @Test
     fun `get returns null when header is absent`() {
         val headers = DeepSeekHeaders(mapOf("X-Request-Id" to listOf("abc")))
-        assertNull(headers["Content-Type"])
+        headers["Content-Type"].shouldBeNull()
     }
 
     @Test
     fun `getAll returns every value for a multi-valued header`() {
         val headers = DeepSeekHeaders(mapOf("Set-Cookie" to listOf("a=1", "b=2")))
-        assertEquals(listOf("a=1", "b=2"), headers.getAll("set-cookie"))
+        headers.getAll("set-cookie") shouldBe listOf("a=1", "b=2")
     }
 
     @Test
     fun `getAll returns empty list when header is absent`() {
         val headers = DeepSeekHeaders(emptyMap())
-        assertEquals(emptyList(), headers.getAll("Content-Type"))
+        headers.getAll("Content-Type") shouldBe emptyList()
     }
 
     @Test
     fun `contains is case-insensitive`() {
         val headers = DeepSeekHeaders(mapOf("Retry-After" to listOf("30")))
-        assertTrue("retry-after" in headers)
-        assertFalse("X-Missing" in headers)
+        ("retry-after" in headers).shouldBeTrue()
+        ("X-Missing" in headers).shouldBeFalse()
     }
 
     @Test
     fun `Empty reports isEmpty and has no names`() {
-        assertTrue(DeepSeekHeaders.Empty.isEmpty())
-        assertEquals(emptySet(), DeepSeekHeaders.Empty.names())
+        DeepSeekHeaders.Empty.isEmpty().shouldBeTrue()
+        DeepSeekHeaders.Empty.names() shouldBe emptySet()
     }
 
     @Test
     fun `equals and hashCode match when entries match`() {
         val a = DeepSeekHeaders(mapOf("X-A" to listOf("1")))
         val b = DeepSeekHeaders(mapOf("X-A" to listOf("1")))
-        assertEquals(a, b)
-        assertEquals(a.hashCode(), b.hashCode())
+        a shouldBe b
+        a.hashCode() shouldBe b.hashCode()
     }
 
     @Test
@@ -64,8 +65,8 @@ class DeepSeekHeadersTests {
             "X-Request-Id" to listOf("abc-123"),
         )
         val mapped = ktorHeaders.toDeepSeekHeaders()
-        assertEquals("application/json", mapped["content-type"])
-        assertEquals("abc-123", mapped["x-request-id"])
+        mapped["content-type"] shouldBe "application/json"
+        mapped["x-request-id"] shouldBe "abc-123"
     }
 
     @Test
@@ -75,12 +76,12 @@ class DeepSeekHeadersTests {
             append("Set-Cookie", "b=2")
         }.build()
         val mapped = ktorHeaders.toDeepSeekHeaders()
-        assertEquals(listOf("a=1", "b=2"), mapped.getAll("Set-Cookie"))
+        mapped.getAll("Set-Cookie") shouldBe listOf("a=1", "b=2")
     }
 
     @Test
     fun `toDeepSeekHeaders on empty returns the shared Empty instance`() {
         val mapped = io.ktor.http.Headers.Empty.toDeepSeekHeaders()
-        assertTrue(mapped === DeepSeekHeaders.Empty)
+        mapped shouldBeSameInstanceAs DeepSeekHeaders.Empty
     }
 }

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/models/FIMCompletionRequestBuilderTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/models/FIMCompletionRequestBuilderTests.kt
@@ -1,25 +1,25 @@
 package org.oremif.deepseek.models
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 class FIMCompletionRequestBuilderTests {
 
     @Test
     fun builderFailsWhenPromptIsNotCalled() {
-        val ex = assertFailsWith<IllegalArgumentException> {
+        val ex = shouldThrow<IllegalArgumentException> {
             FIMCompletionRequest.Builder().build()
         }
-        assertEquals("prompt(...) must be called", ex.message)
+        ex.message shouldBe "prompt(...) must be called"
     }
 
     @Test
     fun streamBuilderFailsWhenPromptIsNotCalled() {
-        val ex = assertFailsWith<IllegalArgumentException> {
+        val ex = shouldThrow<IllegalArgumentException> {
             FIMCompletionRequest.StreamBuilder().build()
         }
-        assertEquals("prompt(...) must be called", ex.message)
+        ex.message shouldBe "prompt(...) must be called"
     }
 
     @Test
@@ -27,7 +27,7 @@ class FIMCompletionRequestBuilderTests {
         val request = FIMCompletionRequest.Builder().apply {
             prompt("def fib(n):")
         }.build()
-        assertEquals("def fib(n):", request.prompt)
+        request.prompt shouldBe "def fib(n):"
     }
 
     @Test
@@ -35,6 +35,6 @@ class FIMCompletionRequestBuilderTests {
         val request = FIMCompletionRequest.StreamBuilder().apply {
             prompt("def fib(n):")
         }.build()
-        assertEquals("def fib(n):", request.prompt)
+        request.prompt shouldBe "def fib(n):"
     }
 }

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/models/ParamsValidationTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/models/ParamsValidationTests.kt
@@ -1,0 +1,127 @@
+package org.oremif.deepseek.models
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlin.test.Test
+
+class ParamsValidationTests {
+
+    @Test
+    fun `chat params accept boundary values`() {
+        shouldNotThrowAny {
+            chatCompletionParams {
+                temperature = 0.0
+                topP = 0.0
+                frequencyPenalty = -2.0
+                presencePenalty = 2.0
+                maxTokens = 1
+                topLogprobs = 0
+            }
+            chatCompletionParams {
+                temperature = 2.0
+                topP = 1.0
+                frequencyPenalty = 2.0
+                presencePenalty = -2.0
+                maxTokens = 8192
+                topLogprobs = 20
+            }
+        }
+    }
+
+    @Test
+    fun `chat params reject topP above 1_0`() {
+        val ex = shouldThrow<IllegalArgumentException> {
+            chatCompletionParams { topP = 1.5 }
+        }
+        ex.message!! shouldContain "topP"
+    }
+
+    @Test
+    fun `chat params reject negative topP`() {
+        shouldThrow<IllegalArgumentException> {
+            chatCompletionParams { topP = -0.1 }
+        }
+    }
+
+    @Test
+    fun `chat params reject temperature above 2_0`() {
+        val ex = shouldThrow<IllegalArgumentException> {
+            chatCompletionParams { temperature = 2.5 }
+        }
+        ex.message!! shouldContain "temperature"
+    }
+
+    @Test
+    fun `chat params reject maxTokens of 0`() {
+        shouldThrow<IllegalArgumentException> {
+            chatCompletionParams { maxTokens = 0 }
+        }
+    }
+
+    @Test
+    fun `chat params reject maxTokens above 8192`() {
+        shouldThrow<IllegalArgumentException> {
+            chatCompletionParams { maxTokens = 9000 }
+        }
+    }
+
+    @Test
+    fun `chat params reject topLogprobs above 20`() {
+        shouldThrow<IllegalArgumentException> {
+            chatCompletionParams { topLogprobs = 21 }
+        }
+    }
+
+    @Test
+    fun `chat stream params validate the same boundaries`() {
+        shouldThrow<IllegalArgumentException> {
+            chatCompletionStreamParams { topP = 1.01 }
+        }
+        shouldThrow<IllegalArgumentException> {
+            chatCompletionStreamParams { frequencyPenalty = -3.0 }
+        }
+    }
+
+    @Test
+    fun `chat stream params force stream = true`() {
+        val params = chatCompletionStreamParams { temperature = 0.7 }
+        params.stream shouldBe true
+    }
+
+    @Test
+    fun `fim params reject logprobs above 20`() {
+        shouldThrow<IllegalArgumentException> {
+            fimCompletionParams { logprobs = 21 }
+        }
+    }
+
+    @Test
+    fun `fim params reject topP above 1_0`() {
+        val ex = shouldThrow<IllegalArgumentException> {
+            fimCompletionParams { topP = 1.1 }
+        }
+        ex.message!! shouldContain "topP"
+    }
+
+    @Test
+    fun `fim params accept boundary values`() {
+        shouldNotThrowAny {
+            fimCompletionParams {
+                temperature = 0.0
+                topP = 1.0
+                frequencyPenalty = -2.0
+                presencePenalty = 2.0
+                maxTokens = 1
+                logprobs = 20
+            }
+        }
+    }
+
+    @Test
+    fun `fim stream params force stream = true`() {
+        val params = fimCompletionStreamParams { maxTokens = 100 }
+        params.stream shouldBe true
+    }
+}

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/models/chatCompletions.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/models/chatCompletions.kt
@@ -1,12 +1,12 @@
 package org.oremif.deepseek.models
 
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 class ChatCompletionTests {
 
@@ -91,11 +91,11 @@ class ChatCompletionTests {
         )
 
         val expected = jsonConfig.decodeFromString<ChatCompletionRequest>(jsonRequest)
-        assertEquals(2, expected.messages.size)
-        assertEquals(2048, expected.maxTokens)
-        assertEquals(ResponseFormat.text, expected.responseFormat)
+        expected.messages.size shouldBe 2
+        expected.maxTokens shouldBe 2048
+        expected.responseFormat shouldBe ResponseFormat.text
 
-        assertEquals(jsonRequest, jsonConfig.encodeToString(request).trimIndent())
+        jsonConfig.encodeToString(request).trimIndent() shouldBe jsonRequest
     }
 
     @Test
@@ -120,11 +120,11 @@ class ChatCompletionTests {
         )
 
         val expected = jsonConfig.decodeFromString<ChatCompletion>(jsonResponse)
-        assertEquals(1, expected.choices.size)
-        assertEquals(FinishReason.STOP, expected.choices[0].finishReason)
-        assertEquals("Hello! How can I help you today?", expected.choices[0].message.content)
-        assertEquals(1705651092L, expected.created)
-        assertEquals(jsonResponse, jsonConfig.encodeToString(response).trimIndent())
+        expected.choices.size shouldBe 1
+        expected.choices[0].finishReason shouldBe FinishReason.STOP
+        expected.choices[0].message.content shouldBe "Hello! How can I help you today?"
+        expected.created shouldBe 1705651092L
+        jsonConfig.encodeToString(response).trimIndent() shouldBe jsonResponse
     }
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -164,14 +164,14 @@ class ChatCompletionTests {
 
         val chunk = streamingJsonConfig.decodeFromString<ChatCompletionChunk>(json)
         val delta = chunk.choices.single().delta
-        assertEquals("assistant", delta.role)
-        assertNull(delta.content)
-        val toolCall = assertNotNull(delta.toolCalls).single()
-        assertEquals(0, toolCall.index)
-        assertEquals("call_abc", toolCall.id)
-        assertEquals(ToolCallType.FUNCTION, toolCall.type)
-        assertEquals("get_weather", toolCall.function?.name)
-        assertEquals("", toolCall.function?.arguments)
+        delta.role shouldBe "assistant"
+        delta.content.shouldBeNull()
+        val toolCall = delta.toolCalls.shouldNotBeNull().single()
+        toolCall.index shouldBe 0
+        toolCall.id shouldBe "call_abc"
+        toolCall.type shouldBe ToolCallType.FUNCTION
+        toolCall.function?.name shouldBe "get_weather"
+        toolCall.function?.arguments shouldBe ""
     }
 
     @Test
@@ -200,11 +200,11 @@ class ChatCompletionTests {
         """.trimIndent()
 
         val chunk = streamingJsonConfig.decodeFromString<ChatCompletionChunk>(json)
-        val toolCall = assertNotNull(chunk.choices.single().delta.toolCalls).single()
-        assertEquals(0, toolCall.index)
-        assertNull(toolCall.id)
-        assertNull(toolCall.type)
-        assertEquals("""{"location":""", toolCall.function?.arguments)
+        val toolCall = chunk.choices.single().delta.toolCalls.shouldNotBeNull().single()
+        toolCall.index shouldBe 0
+        toolCall.id.shouldBeNull()
+        toolCall.type.shouldBeNull()
+        toolCall.function?.arguments shouldBe """{"location":"""
     }
 
     @Test
@@ -227,9 +227,9 @@ class ChatCompletionTests {
 
         val chunk = streamingJsonConfig.decodeFromString<ChatCompletionChunk>(json)
         val choice = chunk.choices.single()
-        assertEquals(FinishReason.TOOL_CALLS, choice.finishReason)
-        assertNull(choice.delta.content)
-        assertNull(choice.delta.toolCalls)
+        choice.finishReason shouldBe FinishReason.TOOL_CALLS
+        choice.delta.content.shouldBeNull()
+        choice.delta.toolCalls.shouldBeNull()
     }
 
     @Test
@@ -251,7 +251,7 @@ class ChatCompletionTests {
         """.trimIndent()
 
         val chunk = streamingJsonConfig.decodeFromString<ChatCompletionChunk>(json)
-        assertEquals("thinking...", chunk.choices.single().delta.reasoningContent)
+        chunk.choices.single().delta.reasoningContent shouldBe "thinking..."
     }
 
     @Test
@@ -264,8 +264,8 @@ class ChatCompletionTests {
         """.trimIndent()
 
         val message = jsonConfig.decodeFromString<ChatCompletionMessage>(json)
-        assertEquals("Hello!", message.content)
-        assertNull(message.toolCalls)
+        message.content shouldBe "Hello!"
+        message.toolCalls.shouldBeNull()
     }
 
     @Test
@@ -279,8 +279,8 @@ class ChatCompletionTests {
         """.trimIndent()
 
         val message = jsonConfig.decodeFromString<ChatCompletionMessage>(json)
-        assertEquals("Hello!", message.content)
-        assertNull(message.toolCalls)
+        message.content shouldBe "Hello!"
+        message.toolCalls.shouldBeNull()
     }
 
     @Test
@@ -300,9 +300,9 @@ class ChatCompletionTests {
         """.trimIndent()
 
         val message = jsonConfig.decodeFromString<ChatCompletionMessage>(json)
-        val toolCalls = assertNotNull(message.toolCalls)
-        assertEquals(1, toolCalls.size)
-        assertEquals("call_abc", toolCalls[0].id)
-        assertEquals("get_weather", toolCalls[0].function.name)
+        val toolCalls = message.toolCalls.shouldNotBeNull()
+        toolCalls.size shouldBe 1
+        toolCalls[0].id shouldBe "call_abc"
+        toolCalls[0].function.name shouldBe "get_weather"
     }
 }

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/testing/MockClients.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/testing/MockClients.kt
@@ -1,0 +1,105 @@
+package org.oremif.deepseek.testing
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineCapability
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.sse.SSE
+import io.ktor.client.plugins.sse.SSECapability
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.client.request.ResponseAdapterAttributeKey
+import io.ktor.client.request.header
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNamingStrategy
+import org.oremif.deepseek.client.DeepSeekClient
+import org.oremif.deepseek.client.DeepSeekClientStream
+
+internal class SseMockEngine(config: MockEngineConfig) : MockEngine(config) {
+    override val supportedCapabilities: Set<HttpClientEngineCapability<out Any>> =
+        super.supportedCapabilities + SSECapability
+
+    @OptIn(InternalAPI::class)
+    override suspend fun execute(data: HttpRequestData): HttpResponseData {
+        val response = super.execute(data)
+        val body = response.body
+        if (body !is ByteReadChannel) return response
+        val adapter = data.attributes.getOrNull(ResponseAdapterAttributeKey) ?: return response
+        val adapted = adapter.adapt(
+            data,
+            response.statusCode,
+            response.headers,
+            body,
+            data.body,
+            response.callContext,
+        ) ?: return response
+        return HttpResponseData(
+            response.statusCode,
+            response.requestTime,
+            response.headers,
+            response.version,
+            adapted,
+            response.callContext,
+        )
+    }
+}
+
+internal fun sseMockEngine(handler: MockRequestHandler): SseMockEngine =
+    SseMockEngine(MockEngineConfig().apply { requestHandlers.add(handler) })
+
+internal fun mockEngine(handler: MockRequestHandler): MockEngine =
+    MockEngine(MockEngineConfig().apply { requestHandlers.add(handler) })
+
+@OptIn(ExperimentalSerializationApi::class)
+internal val TestJson: Json = Json {
+    ignoreUnknownKeys = true
+    namingStrategy = JsonNamingStrategy.SnakeCase
+}
+
+internal fun testClient(
+    engine: HttpClientEngine,
+    token: String = "test-token",
+): DeepSeekClient {
+    val http = HttpClient(engine) {
+        install(ContentNegotiation) { json(TestJson) }
+        defaultRequest {
+            url("https://api.deepseek.com")
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
+    }
+    return DeepSeekClient {
+        jsonConfig(TestJson)
+        httpClient(http)
+    }
+}
+
+internal fun testStreamClient(
+    engine: HttpClientEngine,
+    token: String = "test-token",
+): DeepSeekClientStream {
+    val http = HttpClient(engine) {
+        install(ContentNegotiation) { json(TestJson) }
+        install(SSE)
+        defaultRequest {
+            url("https://api.deepseek.com")
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
+    }
+    return DeepSeekClientStream {
+        jsonConfig(TestJson)
+        httpClient(http)
+    }
+}

--- a/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/utils/RetryPolicyTests.kt
+++ b/deepseek-kotlin/src/commonTest/kotlin/org/oremif/deepseek/utils/RetryPolicyTests.kt
@@ -1,112 +1,109 @@
 package org.oremif.deepseek.utils
 
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.longs.shouldBeLessThan
+import io.kotest.matchers.shouldBe
 import kotlin.random.Random
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class RetryPolicyTests {
 
     @Test
     fun `retries 408 Request Timeout`() {
-        assertTrue(isRetryableStatus(408))
+        isRetryableStatus(408).shouldBeTrue()
     }
 
     @Test
     fun `retries 425 Too Early`() {
-        assertTrue(isRetryableStatus(425))
+        isRetryableStatus(425).shouldBeTrue()
     }
 
     @Test
     fun `retries 429 Too Many Requests`() {
-        assertTrue(isRetryableStatus(429))
+        isRetryableStatus(429).shouldBeTrue()
     }
 
     @Test
     fun `retries 5xx server errors`() {
-        assertTrue(isRetryableStatus(500), "500 Internal Server Error must retry")
-        assertTrue(isRetryableStatus(502), "502 Bad Gateway must retry")
-        assertTrue(isRetryableStatus(503), "503 Service Unavailable must retry")
-        assertTrue(isRetryableStatus(504), "504 Gateway Timeout must retry")
-        assertTrue(isRetryableStatus(599), "any 5xx must retry")
+        isRetryableStatus(500).shouldBeTrue()
+        isRetryableStatus(502).shouldBeTrue()
+        isRetryableStatus(503).shouldBeTrue()
+        isRetryableStatus(504).shouldBeTrue()
+        isRetryableStatus(599).shouldBeTrue()
     }
 
     @Test
     fun `does not retry 400 Bad Request`() {
-        assertFalse(isRetryableStatus(400))
+        isRetryableStatus(400).shouldBeFalse()
     }
 
     @Test
     fun `does not retry 401 Unauthorized`() {
-        assertFalse(isRetryableStatus(401))
+        isRetryableStatus(401).shouldBeFalse()
     }
 
     @Test
     fun `does not retry 402 Insufficient Balance`() {
-        assertFalse(isRetryableStatus(402))
+        isRetryableStatus(402).shouldBeFalse()
     }
 
     @Test
     fun `does not retry 403 Forbidden`() {
-        assertFalse(isRetryableStatus(403))
+        isRetryableStatus(403).shouldBeFalse()
     }
 
     @Test
     fun `does not retry 404 Not Found`() {
-        assertFalse(isRetryableStatus(404))
+        isRetryableStatus(404).shouldBeFalse()
     }
 
     @Test
     fun `does not retry 422 Unprocessable Entity`() {
-        assertFalse(isRetryableStatus(422))
+        isRetryableStatus(422).shouldBeFalse()
     }
 
     @Test
     fun `does not retry 2xx success`() {
-        assertFalse(isRetryableStatus(200))
-        assertFalse(isRetryableStatus(201))
-        assertFalse(isRetryableStatus(204))
+        isRetryableStatus(200).shouldBeFalse()
+        isRetryableStatus(201).shouldBeFalse()
+        isRetryableStatus(204).shouldBeFalse()
     }
 
     @Test
     fun `does not retry 3xx redirects`() {
-        assertFalse(isRetryableStatus(301))
-        assertFalse(isRetryableStatus(302))
-        assertFalse(isRetryableStatus(304))
+        isRetryableStatus(301).shouldBeFalse()
+        isRetryableStatus(302).shouldBeFalse()
+        isRetryableStatus(304).shouldBeFalse()
     }
 
     @Test
     fun `delay grows exponentially with retry count`() {
         val base = 500L
-        val d1 = computeRetryDelayMillis(retry = 1, baseMillis = base, jitterMillis = 0L)
-        val d2 = computeRetryDelayMillis(retry = 2, baseMillis = base, jitterMillis = 0L)
-        val d3 = computeRetryDelayMillis(retry = 3, baseMillis = base, jitterMillis = 0L)
-        assertEquals(1_000L, d1, "retry=1 should yield base * 2^1")
-        assertEquals(2_000L, d2, "retry=2 should yield base * 2^2")
-        assertEquals(4_000L, d3, "retry=3 should yield base * 2^3")
+        computeRetryDelayMillis(retry = 1, baseMillis = base, jitterMillis = 0L) shouldBe 1_000L
+        computeRetryDelayMillis(retry = 2, baseMillis = base, jitterMillis = 0L) shouldBe 2_000L
+        computeRetryDelayMillis(retry = 3, baseMillis = base, jitterMillis = 0L) shouldBe 4_000L
     }
 
     @Test
     fun `delay is capped at maxMillis`() {
-        val d = computeRetryDelayMillis(
+        computeRetryDelayMillis(
             retry = 10,
             baseMillis = 500L,
             maxMillis = 5_000L,
             jitterMillis = 0L,
-        )
-        assertEquals(5_000L, d, "exponential term must be clamped to maxMillis")
+        ) shouldBe 5_000L
     }
 
     @Test
     fun `delay does not overflow for large retry counts`() {
-        val d = computeRetryDelayMillis(
+        computeRetryDelayMillis(
             retry = 60,
             baseMillis = 500L,
             maxMillis = 30_000L,
             jitterMillis = 0L,
-        )
-        assertEquals(30_000L, d, "large retry counts must still clamp to maxMillis, not overflow")
+        ) shouldBe 30_000L
     }
 
     @Test
@@ -120,8 +117,8 @@ class RetryPolicyTests {
                 jitterMillis = jitter,
                 random = Random(seed.toLong()),
             )
-            assertTrue(d >= 1_000L, "delay $d must be >= exponential floor 1000 (seed=$seed)")
-            assertTrue(d < 1_000L + jitter, "delay $d must be < 1000 + jitter=$jitter (seed=$seed)")
+            d.shouldBeGreaterThanOrEqual(1_000L)
+            d.shouldBeLessThan(1_000L + jitter)
         }
     }
 
@@ -129,8 +126,8 @@ class RetryPolicyTests {
     fun `zero jitter is deterministic`() {
         val d1 = computeRetryDelayMillis(retry = 2, baseMillis = 500L, jitterMillis = 0L)
         val d2 = computeRetryDelayMillis(retry = 2, baseMillis = 500L, jitterMillis = 0L)
-        assertEquals(d1, d2)
-        assertEquals(2_000L, d1)
+        d1 shouldBe d2
+        d1 shouldBe 2_000L
     }
 
     @Test
@@ -142,6 +139,6 @@ class RetryPolicyTests {
         val d2 = computeRetryDelayMillis(
             retry = 2, baseMillis = 500L, jitterMillis = 250L, random = Random(seed),
         )
-        assertEquals(d1, d2, "same seed must produce deterministic delay")
+        d1 shouldBe d2
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ serialization = "1.11.0"
 coroutines = "1.10.2"
 ktor = "3.4.2"
 slf4j = "2.0.17"
+kotest = "6.1.11"
 maven-publish = "0.36.0"
 binary-compatibility-validator = "0.18.1"
 
@@ -31,6 +32,7 @@ ktor-client-js = { group = "io.ktor", name = "ktor-client-js", version.ref = "kt
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
+kotest-assertions-core = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 
 [plugins]


### PR DESCRIPTION
## Summary

Addresses finding 5.1 (test coverage too narrow) from `findings.md`.

- Adds `kotest-assertions-core` to `commonTest` (6.1.11) and migrates
  existing assertions from `kotlin.test.assert*` to kotest's DSL.
  `@Test` and `runTest` stay on `kotlin.test` / `kotlinx-coroutines-test`.
- Adds MockEngine-based tests for each public endpoint (chat, chat
  stream, FIM, user balance, models) — covering request shape, response
  parsing, and one representative error mapping per endpoint.
- Adds parameter validation tests for `ChatCompletionParams` and
  `FIMCompletionParams` boundary values (topP, temperature, maxTokens,
  logprobs / topLogprobs).
- Factors shared test infrastructure into
  `org.oremif.deepseek.testing.MockClients`, including a custom
  `SseMockEngine` that applies ktor's `ResponseAdapter` so SSE success
  paths can be tested without a real server (stock ktor `MockEngine`
  doesn't invoke the adapter itself).

## Scope

Deliberately kept pragmatic over exhaustive — the goal was to cover the
basics, not every branch. Existing tests that already covered other
findings (retry policy, SSE error paths, exception mapping, builder
behavior) remain intact, just re-expressed in kotest style.

Test count: 100 (was 72), all passing on JVM, iOS simulator, macOS and
wasmJs (Node + browser). `apiCheck` is unchanged.

## Test plan

- [x] `./gradlew :deepseek-kotlin:jvmTest`
- [x] `./gradlew :deepseek-kotlin:iosSimulatorArm64Test`
- [x] `./gradlew :deepseek-kotlin:macosArm64Test`
- [x] `./gradlew :deepseek-kotlin:wasmJsNodeTest`
- [x] `./gradlew :deepseek-kotlin:wasmJsBrowserTest`
- [x] `./gradlew :deepseek-kotlin:apiCheck`
- [x] `./gradlew :deepseek-kotlin:check`