### PR TITLE
align chat and FIM models with live DeepSeek API

### DIFF
--- a/deepseek-kotlin/api/deepseek-kotlin.klib.api
+++ b/deepseek-kotlin/api/deepseek-kotlin.klib.api
@@ -79,6 +79,22 @@ final enum class org.oremif.deepseek.models/ModelObjectType : kotlin/Enum<org.or
     }
 }
 
+final enum class org.oremif.deepseek.models/ThinkingType : kotlin/Enum<org.oremif.deepseek.models/ThinkingType> { // org.oremif.deepseek.models/ThinkingType|null[0]
+    enum entry DISABLED // org.oremif.deepseek.models/ThinkingType.DISABLED|null[0]
+    enum entry ENABLED // org.oremif.deepseek.models/ThinkingType.ENABLED|null[0]
+
+    final val entries // org.oremif.deepseek.models/ThinkingType.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<org.oremif.deepseek.models/ThinkingType> // org.oremif.deepseek.models/ThinkingType.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): org.oremif.deepseek.models/ThinkingType // org.oremif.deepseek.models/ThinkingType.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<org.oremif.deepseek.models/ThinkingType> // org.oremif.deepseek.models/ThinkingType.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // org.oremif.deepseek.models/ThinkingType.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<org.oremif.deepseek.models/ThinkingType> // org.oremif.deepseek.models/ThinkingType.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // org.oremif.deepseek.models/ThinkingType.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
 final enum class org.oremif.deepseek.models/ToolCallType : kotlin/Enum<org.oremif.deepseek.models/ToolCallType> { // org.oremif.deepseek.models/ToolCallType|null[0]
     enum entry FUNCTION // org.oremif.deepseek.models/ToolCallType.FUNCTION|null[0]
 
@@ -520,6 +536,8 @@ final class org.oremif.deepseek.models/ChatCompletionParams : org.oremif.deepsee
         final fun <get-stream>(): kotlin/Boolean? // org.oremif.deepseek.models/ChatCompletionParams.stream.<get-stream>|<get-stream>(){}[0]
     final val streamOptions // org.oremif.deepseek.models/ChatCompletionParams.streamOptions|{}streamOptions[0]
         final fun <get-streamOptions>(): org.oremif.deepseek.models/StreamOptions? // org.oremif.deepseek.models/ChatCompletionParams.streamOptions.<get-streamOptions>|<get-streamOptions>(){}[0]
+    final val thinking // org.oremif.deepseek.models/ChatCompletionParams.thinking|{}thinking[0]
+        final fun <get-thinking>(): org.oremif.deepseek.models/Thinking? // org.oremif.deepseek.models/ChatCompletionParams.thinking.<get-thinking>|<get-thinking>(){}[0]
     final val toolChoice // org.oremif.deepseek.models/ChatCompletionParams.toolChoice|{}toolChoice[0]
         final fun <get-toolChoice>(): org.oremif.deepseek.models/ToolChoice? // org.oremif.deepseek.models/ChatCompletionParams.toolChoice.<get-toolChoice>|<get-toolChoice>(){}[0]
     final val tools // org.oremif.deepseek.models/ChatCompletionParams.tools|{}tools[0]
@@ -527,7 +545,7 @@ final class org.oremif.deepseek.models/ChatCompletionParams : org.oremif.deepsee
     final val topLogprobs // org.oremif.deepseek.models/ChatCompletionParams.topLogprobs|{}topLogprobs[0]
         final fun <get-topLogprobs>(): kotlin/Int? // org.oremif.deepseek.models/ChatCompletionParams.topLogprobs.<get-topLogprobs>|<get-topLogprobs>(){}[0]
 
-    final fun copy(org.oremif.deepseek.models/ChatModel = ..., kotlin/Double? = ..., kotlin/Int? = ..., kotlin/Double? = ..., org.oremif.deepseek.models/ResponseFormat? = ..., org.oremif.deepseek.models/StopReason? = ..., kotlin/Boolean? = ..., org.oremif.deepseek.models/StreamOptions? = ..., kotlin/Double? = ..., kotlin/Double? = ..., kotlin.collections/List<org.oremif.deepseek.models/Tool>? = ..., org.oremif.deepseek.models/ToolChoice? = ..., kotlin/Boolean? = ..., kotlin/Int? = ...): org.oremif.deepseek.models/ChatCompletionParams // org.oremif.deepseek.models/ChatCompletionParams.copy|copy(org.oremif.deepseek.models.ChatModel;kotlin.Double?;kotlin.Int?;kotlin.Double?;org.oremif.deepseek.models.ResponseFormat?;org.oremif.deepseek.models.StopReason?;kotlin.Boolean?;org.oremif.deepseek.models.StreamOptions?;kotlin.Double?;kotlin.Double?;kotlin.collections.List<org.oremif.deepseek.models.Tool>?;org.oremif.deepseek.models.ToolChoice?;kotlin.Boolean?;kotlin.Int?){}[0]
+    final fun copy(org.oremif.deepseek.models/ChatModel = ..., kotlin/Double? = ..., kotlin/Int? = ..., kotlin/Double? = ..., org.oremif.deepseek.models/ResponseFormat? = ..., org.oremif.deepseek.models/StopReason? = ..., kotlin/Boolean? = ..., org.oremif.deepseek.models/StreamOptions? = ..., kotlin/Double? = ..., kotlin/Double? = ..., kotlin.collections/List<org.oremif.deepseek.models/Tool>? = ..., org.oremif.deepseek.models/ToolChoice? = ..., kotlin/Boolean? = ..., kotlin/Int? = ..., org.oremif.deepseek.models/Thinking? = ...): org.oremif.deepseek.models/ChatCompletionParams // org.oremif.deepseek.models/ChatCompletionParams.copy|copy(org.oremif.deepseek.models.ChatModel;kotlin.Double?;kotlin.Int?;kotlin.Double?;org.oremif.deepseek.models.ResponseFormat?;org.oremif.deepseek.models.StopReason?;kotlin.Boolean?;org.oremif.deepseek.models.StreamOptions?;kotlin.Double?;kotlin.Double?;kotlin.collections.List<org.oremif.deepseek.models.Tool>?;org.oremif.deepseek.models.ToolChoice?;kotlin.Boolean?;kotlin.Int?;org.oremif.deepseek.models.Thinking?){}[0]
     final fun createRequest(kotlin.collections/List<org.oremif.deepseek.models/ChatMessage>): org.oremif.deepseek.models/ChatCompletionRequest // org.oremif.deepseek.models/ChatCompletionParams.createRequest|createRequest(kotlin.collections.List<org.oremif.deepseek.models.ChatMessage>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // org.oremif.deepseek.models/ChatCompletionParams.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // org.oremif.deepseek.models/ChatCompletionParams.hashCode|hashCode(){}[0]
@@ -560,6 +578,9 @@ final class org.oremif.deepseek.models/ChatCompletionParams : org.oremif.deepsee
         final var temperature // org.oremif.deepseek.models/ChatCompletionParams.Builder.temperature|{}temperature[0]
             final fun <get-temperature>(): kotlin/Double? // org.oremif.deepseek.models/ChatCompletionParams.Builder.temperature.<get-temperature>|<get-temperature>(){}[0]
             final fun <set-temperature>(kotlin/Double?) // org.oremif.deepseek.models/ChatCompletionParams.Builder.temperature.<set-temperature>|<set-temperature>(kotlin.Double?){}[0]
+        final var thinking // org.oremif.deepseek.models/ChatCompletionParams.Builder.thinking|{}thinking[0]
+            final fun <get-thinking>(): org.oremif.deepseek.models/Thinking? // org.oremif.deepseek.models/ChatCompletionParams.Builder.thinking.<get-thinking>|<get-thinking>(){}[0]
+            final fun <set-thinking>(org.oremif.deepseek.models/Thinking?) // org.oremif.deepseek.models/ChatCompletionParams.Builder.thinking.<set-thinking>|<set-thinking>(org.oremif.deepseek.models.Thinking?){}[0]
         final var toolChoice // org.oremif.deepseek.models/ChatCompletionParams.Builder.toolChoice|{}toolChoice[0]
             final fun <get-toolChoice>(): org.oremif.deepseek.models/ToolChoice? // org.oremif.deepseek.models/ChatCompletionParams.Builder.toolChoice.<get-toolChoice>|<get-toolChoice>(){}[0]
             final fun <set-toolChoice>(org.oremif.deepseek.models/ToolChoice?) // org.oremif.deepseek.models/ChatCompletionParams.Builder.toolChoice.<set-toolChoice>|<set-toolChoice>(org.oremif.deepseek.models.ToolChoice?){}[0]
@@ -604,6 +625,9 @@ final class org.oremif.deepseek.models/ChatCompletionParams : org.oremif.deepsee
         final var temperature // org.oremif.deepseek.models/ChatCompletionParams.StreamBuilder.temperature|{}temperature[0]
             final fun <get-temperature>(): kotlin/Double? // org.oremif.deepseek.models/ChatCompletionParams.StreamBuilder.temperature.<get-temperature>|<get-temperature>(){}[0]
             final fun <set-temperature>(kotlin/Double?) // org.oremif.deepseek.models/ChatCompletionParams.StreamBuilder.temperature.<set-temperature>|<set-temperature>(kotlin.Double?){}[0]
+        final var thinking // org.oremif.deepseek.models/ChatCompletionParams.StreamBuilder.thinking|{}thinking[0]
+            final fun <get-thinking>(): org.oremif.deepseek.models/Thinking? // org.oremif.deepseek.models/ChatCompletionParams.StreamBuilder.thinking.<get-thinking>|<get-thinking>(){}[0]
+            final fun <set-thinking>(org.oremif.deepseek.models/Thinking?) // org.oremif.deepseek.models/ChatCompletionParams.StreamBuilder.thinking.<set-thinking>|<set-thinking>(org.oremif.deepseek.models.Thinking?){}[0]
         final var toolChoice // org.oremif.deepseek.models/ChatCompletionParams.StreamBuilder.toolChoice|{}toolChoice[0]
             final fun <get-toolChoice>(): org.oremif.deepseek.models/ToolChoice? // org.oremif.deepseek.models/ChatCompletionParams.StreamBuilder.toolChoice.<get-toolChoice>|<get-toolChoice>(){}[0]
             final fun <set-toolChoice>(org.oremif.deepseek.models/ToolChoice?) // org.oremif.deepseek.models/ChatCompletionParams.StreamBuilder.toolChoice.<set-toolChoice>|<set-toolChoice>(org.oremif.deepseek.models.ToolChoice?){}[0]
@@ -620,7 +644,7 @@ final class org.oremif.deepseek.models/ChatCompletionParams : org.oremif.deepsee
 }
 
 final class org.oremif.deepseek.models/ChatCompletionRequest { // org.oremif.deepseek.models/ChatCompletionRequest|null[0]
-    constructor <init>(kotlin.collections/List<org.oremif.deepseek.models/ChatMessage>, org.oremif.deepseek.models/ChatModel, kotlin/Double? = ..., kotlin/Int? = ..., kotlin/Double? = ..., org.oremif.deepseek.models/ResponseFormat? = ..., org.oremif.deepseek.models/StopReason? = ..., kotlin/Boolean? = ..., org.oremif.deepseek.models/StreamOptions? = ..., kotlin/Double? = ..., kotlin/Double? = ..., kotlin.collections/List<org.oremif.deepseek.models/Tool>? = ..., org.oremif.deepseek.models/ToolChoice? = ..., kotlin/Boolean? = ..., kotlin/Int? = ...) // org.oremif.deepseek.models/ChatCompletionRequest.<init>|<init>(kotlin.collections.List<org.oremif.deepseek.models.ChatMessage>;org.oremif.deepseek.models.ChatModel;kotlin.Double?;kotlin.Int?;kotlin.Double?;org.oremif.deepseek.models.ResponseFormat?;org.oremif.deepseek.models.StopReason?;kotlin.Boolean?;org.oremif.deepseek.models.StreamOptions?;kotlin.Double?;kotlin.Double?;kotlin.collections.List<org.oremif.deepseek.models.Tool>?;org.oremif.deepseek.models.ToolChoice?;kotlin.Boolean?;kotlin.Int?){}[0]
+    constructor <init>(kotlin.collections/List<org.oremif.deepseek.models/ChatMessage>, org.oremif.deepseek.models/ChatModel, kotlin/Double? = ..., kotlin/Int? = ..., kotlin/Double? = ..., org.oremif.deepseek.models/ResponseFormat? = ..., org.oremif.deepseek.models/StopReason? = ..., kotlin/Boolean? = ..., org.oremif.deepseek.models/StreamOptions? = ..., kotlin/Double? = ..., kotlin/Double? = ..., kotlin.collections/List<org.oremif.deepseek.models/Tool>? = ..., org.oremif.deepseek.models/ToolChoice? = ..., kotlin/Boolean? = ..., kotlin/Int? = ..., org.oremif.deepseek.models/Thinking? = ...) // org.oremif.deepseek.models/ChatCompletionRequest.<init>|<init>(kotlin.collections.List<org.oremif.deepseek.models.ChatMessage>;org.oremif.deepseek.models.ChatModel;kotlin.Double?;kotlin.Int?;kotlin.Double?;org.oremif.deepseek.models.ResponseFormat?;org.oremif.deepseek.models.StopReason?;kotlin.Boolean?;org.oremif.deepseek.models.StreamOptions?;kotlin.Double?;kotlin.Double?;kotlin.collections.List<org.oremif.deepseek.models.Tool>?;org.oremif.deepseek.models.ToolChoice?;kotlin.Boolean?;kotlin.Int?;org.oremif.deepseek.models.Thinking?){}[0]
 
     final val frequencyPenalty // org.oremif.deepseek.models/ChatCompletionRequest.frequencyPenalty|{}frequencyPenalty[0]
         final fun <get-frequencyPenalty>(): kotlin/Double? // org.oremif.deepseek.models/ChatCompletionRequest.frequencyPenalty.<get-frequencyPenalty>|<get-frequencyPenalty>(){}[0]
@@ -644,6 +668,8 @@ final class org.oremif.deepseek.models/ChatCompletionRequest { // org.oremif.dee
         final fun <get-streamOptions>(): org.oremif.deepseek.models/StreamOptions? // org.oremif.deepseek.models/ChatCompletionRequest.streamOptions.<get-streamOptions>|<get-streamOptions>(){}[0]
     final val temperature // org.oremif.deepseek.models/ChatCompletionRequest.temperature|{}temperature[0]
         final fun <get-temperature>(): kotlin/Double? // org.oremif.deepseek.models/ChatCompletionRequest.temperature.<get-temperature>|<get-temperature>(){}[0]
+    final val thinking // org.oremif.deepseek.models/ChatCompletionRequest.thinking|{}thinking[0]
+        final fun <get-thinking>(): org.oremif.deepseek.models/Thinking? // org.oremif.deepseek.models/ChatCompletionRequest.thinking.<get-thinking>|<get-thinking>(){}[0]
     final val toolChoice // org.oremif.deepseek.models/ChatCompletionRequest.toolChoice|{}toolChoice[0]
         final fun <get-toolChoice>(): org.oremif.deepseek.models/ToolChoice? // org.oremif.deepseek.models/ChatCompletionRequest.toolChoice.<get-toolChoice>|<get-toolChoice>(){}[0]
     final val tools // org.oremif.deepseek.models/ChatCompletionRequest.tools|{}tools[0]
@@ -939,7 +965,7 @@ final class org.oremif.deepseek.models/FIMCompletionRequest { // org.oremif.deep
 }
 
 final class org.oremif.deepseek.models/FIMLogProbs { // org.oremif.deepseek.models/FIMLogProbs|null[0]
-    constructor <init>(kotlin.collections/List<kotlin/Int>, kotlin.collections/List<kotlin/Double>, kotlin.collections/List<kotlin/String>, kotlin.collections/List<org.oremif.deepseek.models/TopLogProb>?) // org.oremif.deepseek.models/FIMLogProbs.<init>|<init>(kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Double>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<org.oremif.deepseek.models.TopLogProb>?){}[0]
+    constructor <init>(kotlin.collections/List<kotlin/Int>, kotlin.collections/List<kotlin/Double>, kotlin.collections/List<kotlin/String>, kotlin.collections/List<kotlin.collections/Map<kotlin/String, kotlin/Double>>? = ...) // org.oremif.deepseek.models/FIMLogProbs.<init>|<init>(kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Double>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.collections.Map<kotlin.String,kotlin.Double>>?){}[0]
 
     final val textOffset // org.oremif.deepseek.models/FIMLogProbs.textOffset|{}textOffset[0]
         final fun <get-textOffset>(): kotlin.collections/List<kotlin/Int> // org.oremif.deepseek.models/FIMLogProbs.textOffset.<get-textOffset>|<get-textOffset>(){}[0]
@@ -948,7 +974,7 @@ final class org.oremif.deepseek.models/FIMLogProbs { // org.oremif.deepseek.mode
     final val tokens // org.oremif.deepseek.models/FIMLogProbs.tokens|{}tokens[0]
         final fun <get-tokens>(): kotlin.collections/List<kotlin/String> // org.oremif.deepseek.models/FIMLogProbs.tokens.<get-tokens>|<get-tokens>(){}[0]
     final val topLogprobs // org.oremif.deepseek.models/FIMLogProbs.topLogprobs|{}topLogprobs[0]
-        final fun <get-topLogprobs>(): kotlin.collections/List<org.oremif.deepseek.models/TopLogProb>? // org.oremif.deepseek.models/FIMLogProbs.topLogprobs.<get-topLogprobs>|<get-topLogprobs>(){}[0]
+        final fun <get-topLogprobs>(): kotlin.collections/List<kotlin.collections/Map<kotlin/String, kotlin/Double>>? // org.oremif.deepseek.models/FIMLogProbs.topLogprobs.<get-topLogprobs>|<get-topLogprobs>(){}[0]
 
     final fun equals(kotlin/Any?): kotlin/Boolean // org.oremif.deepseek.models/FIMLogProbs.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // org.oremif.deepseek.models/FIMLogProbs.hashCode|hashCode(){}[0]
@@ -1168,6 +1194,30 @@ final class org.oremif.deepseek.models/ModelInfo { // org.oremif.deepseek.models
     }
 }
 
+final class org.oremif.deepseek.models/PromptTokensDetails { // org.oremif.deepseek.models/PromptTokensDetails|null[0]
+    constructor <init>(kotlin/Int? = ...) // org.oremif.deepseek.models/PromptTokensDetails.<init>|<init>(kotlin.Int?){}[0]
+
+    final val cachedTokens // org.oremif.deepseek.models/PromptTokensDetails.cachedTokens|{}cachedTokens[0]
+        final fun <get-cachedTokens>(): kotlin/Int? // org.oremif.deepseek.models/PromptTokensDetails.cachedTokens.<get-cachedTokens>|<get-cachedTokens>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // org.oremif.deepseek.models/PromptTokensDetails.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // org.oremif.deepseek.models/PromptTokensDetails.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // org.oremif.deepseek.models/PromptTokensDetails.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<org.oremif.deepseek.models/PromptTokensDetails> { // org.oremif.deepseek.models/PromptTokensDetails.$serializer|null[0]
+        final val descriptor // org.oremif.deepseek.models/PromptTokensDetails.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // org.oremif.deepseek.models/PromptTokensDetails.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // org.oremif.deepseek.models/PromptTokensDetails.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): org.oremif.deepseek.models/PromptTokensDetails // org.oremif.deepseek.models/PromptTokensDetails.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, org.oremif.deepseek.models/PromptTokensDetails) // org.oremif.deepseek.models/PromptTokensDetails.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;org.oremif.deepseek.models.PromptTokensDetails){}[0]
+    }
+
+    final object Companion { // org.oremif.deepseek.models/PromptTokensDetails.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<org.oremif.deepseek.models/PromptTokensDetails> // org.oremif.deepseek.models/PromptTokensDetails.Companion.serializer|serializer(){}[0]
+    }
+}
+
 final class org.oremif.deepseek.models/ResponseFormat { // org.oremif.deepseek.models/ResponseFormat|null[0]
     final val type // org.oremif.deepseek.models/ResponseFormat.type|{}type[0]
         final fun <get-type>(): kotlin/String // org.oremif.deepseek.models/ResponseFormat.type.<get-type>|<get-type>(){}[0]
@@ -1257,6 +1307,32 @@ final class org.oremif.deepseek.models/SystemMessage : org.oremif.deepseek.model
 
     final object Companion { // org.oremif.deepseek.models/SystemMessage.Companion|null[0]
         final fun serializer(): kotlinx.serialization/KSerializer<org.oremif.deepseek.models/SystemMessage> // org.oremif.deepseek.models/SystemMessage.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class org.oremif.deepseek.models/Thinking { // org.oremif.deepseek.models/Thinking|null[0]
+    constructor <init>(org.oremif.deepseek.models/ThinkingType) // org.oremif.deepseek.models/Thinking.<init>|<init>(org.oremif.deepseek.models.ThinkingType){}[0]
+
+    final val type // org.oremif.deepseek.models/Thinking.type|{}type[0]
+        final fun <get-type>(): org.oremif.deepseek.models/ThinkingType // org.oremif.deepseek.models/Thinking.type.<get-type>|<get-type>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // org.oremif.deepseek.models/Thinking.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // org.oremif.deepseek.models/Thinking.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // org.oremif.deepseek.models/Thinking.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<org.oremif.deepseek.models/Thinking> { // org.oremif.deepseek.models/Thinking.$serializer|null[0]
+        final val descriptor // org.oremif.deepseek.models/Thinking.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // org.oremif.deepseek.models/Thinking.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // org.oremif.deepseek.models/Thinking.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): org.oremif.deepseek.models/Thinking // org.oremif.deepseek.models/Thinking.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, org.oremif.deepseek.models/Thinking) // org.oremif.deepseek.models/Thinking.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;org.oremif.deepseek.models.Thinking){}[0]
+    }
+
+    final object Companion { // org.oremif.deepseek.models/Thinking.Companion|null[0]
+        final val $childSerializers // org.oremif.deepseek.models/Thinking.Companion.$childSerializers|{}$childSerializers[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<org.oremif.deepseek.models/Thinking> // org.oremif.deepseek.models/Thinking.Companion.serializer|serializer(){}[0]
     }
 }
 
@@ -1407,7 +1483,7 @@ final class org.oremif.deepseek.models/TopLogProb { // org.oremif.deepseek.model
 }
 
 final class org.oremif.deepseek.models/Usage { // org.oremif.deepseek.models/Usage|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int, kotlin/Int? = ..., kotlin/Int? = ..., kotlin/Int, org.oremif.deepseek.models/CompletionTokenDetails? = ...) // org.oremif.deepseek.models/Usage.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int?;kotlin.Int?;kotlin.Int;org.oremif.deepseek.models.CompletionTokenDetails?){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int, kotlin/Int? = ..., kotlin/Int? = ..., org.oremif.deepseek.models/PromptTokensDetails? = ..., kotlin/Int, org.oremif.deepseek.models/CompletionTokenDetails? = ...) // org.oremif.deepseek.models/Usage.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int?;kotlin.Int?;org.oremif.deepseek.models.PromptTokensDetails?;kotlin.Int;org.oremif.deepseek.models.CompletionTokenDetails?){}[0]
 
     final val completionTokens // org.oremif.deepseek.models/Usage.completionTokens|{}completionTokens[0]
         final fun <get-completionTokens>(): kotlin/Int // org.oremif.deepseek.models/Usage.completionTokens.<get-completionTokens>|<get-completionTokens>(){}[0]
@@ -1419,6 +1495,8 @@ final class org.oremif.deepseek.models/Usage { // org.oremif.deepseek.models/Usa
         final fun <get-promptCacheMissTokens>(): kotlin/Int? // org.oremif.deepseek.models/Usage.promptCacheMissTokens.<get-promptCacheMissTokens>|<get-promptCacheMissTokens>(){}[0]
     final val promptTokens // org.oremif.deepseek.models/Usage.promptTokens|{}promptTokens[0]
         final fun <get-promptTokens>(): kotlin/Int // org.oremif.deepseek.models/Usage.promptTokens.<get-promptTokens>|<get-promptTokens>(){}[0]
+    final val promptTokensDetails // org.oremif.deepseek.models/Usage.promptTokensDetails|{}promptTokensDetails[0]
+        final fun <get-promptTokensDetails>(): org.oremif.deepseek.models/PromptTokensDetails? // org.oremif.deepseek.models/Usage.promptTokensDetails.<get-promptTokensDetails>|<get-promptTokensDetails>(){}[0]
     final val totalTokens // org.oremif.deepseek.models/Usage.totalTokens|{}totalTokens[0]
         final fun <get-totalTokens>(): kotlin/Int // org.oremif.deepseek.models/Usage.totalTokens.<get-totalTokens>|<get-totalTokens>(){}[0]
 

--- a/deepseek-kotlin/api/jvm/deepseek-kotlin.api
+++ b/deepseek-kotlin/api/jvm/deepseek-kotlin.api
@@ -487,8 +487,8 @@ public final class org/oremif/deepseek/models/ChatCompletionNamedToolChoice$Comp
 }
 
 public final class org/oremif/deepseek/models/ChatCompletionParams : org/oremif/deepseek/models/DeepSeekParams {
-	public final fun copy (Lorg/oremif/deepseek/models/ChatModel;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Double;Lorg/oremif/deepseek/models/ResponseFormat;Lorg/oremif/deepseek/models/StopReason;Ljava/lang/Boolean;Lorg/oremif/deepseek/models/StreamOptions;Ljava/lang/Double;Ljava/lang/Double;Ljava/util/List;Lorg/oremif/deepseek/models/ToolChoice;Ljava/lang/Boolean;Ljava/lang/Integer;)Lorg/oremif/deepseek/models/ChatCompletionParams;
-	public static synthetic fun copy$default (Lorg/oremif/deepseek/models/ChatCompletionParams;Lorg/oremif/deepseek/models/ChatModel;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Double;Lorg/oremif/deepseek/models/ResponseFormat;Lorg/oremif/deepseek/models/StopReason;Ljava/lang/Boolean;Lorg/oremif/deepseek/models/StreamOptions;Ljava/lang/Double;Ljava/lang/Double;Ljava/util/List;Lorg/oremif/deepseek/models/ToolChoice;Ljava/lang/Boolean;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/oremif/deepseek/models/ChatCompletionParams;
+	public final fun copy (Lorg/oremif/deepseek/models/ChatModel;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Double;Lorg/oremif/deepseek/models/ResponseFormat;Lorg/oremif/deepseek/models/StopReason;Ljava/lang/Boolean;Lorg/oremif/deepseek/models/StreamOptions;Ljava/lang/Double;Ljava/lang/Double;Ljava/util/List;Lorg/oremif/deepseek/models/ToolChoice;Ljava/lang/Boolean;Ljava/lang/Integer;Lorg/oremif/deepseek/models/Thinking;)Lorg/oremif/deepseek/models/ChatCompletionParams;
+	public static synthetic fun copy$default (Lorg/oremif/deepseek/models/ChatCompletionParams;Lorg/oremif/deepseek/models/ChatModel;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Double;Lorg/oremif/deepseek/models/ResponseFormat;Lorg/oremif/deepseek/models/StopReason;Ljava/lang/Boolean;Lorg/oremif/deepseek/models/StreamOptions;Ljava/lang/Double;Ljava/lang/Double;Ljava/util/List;Lorg/oremif/deepseek/models/ToolChoice;Ljava/lang/Boolean;Ljava/lang/Integer;Lorg/oremif/deepseek/models/Thinking;ILjava/lang/Object;)Lorg/oremif/deepseek/models/ChatCompletionParams;
 	public final fun createRequest (Ljava/util/List;)Lorg/oremif/deepseek/models/ChatCompletionRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLogprobs ()Ljava/lang/Boolean;
@@ -496,6 +496,7 @@ public final class org/oremif/deepseek/models/ChatCompletionParams : org/oremif/
 	public final fun getResponseFormat ()Lorg/oremif/deepseek/models/ResponseFormat;
 	public final fun getStream ()Ljava/lang/Boolean;
 	public final fun getStreamOptions ()Lorg/oremif/deepseek/models/StreamOptions;
+	public final fun getThinking ()Lorg/oremif/deepseek/models/Thinking;
 	public final fun getToolChoice ()Lorg/oremif/deepseek/models/ToolChoice;
 	public final fun getTools ()Ljava/util/List;
 	public final fun getTopLogprobs ()Ljava/lang/Integer;
@@ -513,6 +514,7 @@ public final class org/oremif/deepseek/models/ChatCompletionParams$Builder {
 	public final fun getResponseFormat ()Lorg/oremif/deepseek/models/ResponseFormat;
 	public final fun getStop ()Lorg/oremif/deepseek/models/StopReason;
 	public final fun getTemperature ()Ljava/lang/Double;
+	public final fun getThinking ()Lorg/oremif/deepseek/models/Thinking;
 	public final fun getToolChoice ()Lorg/oremif/deepseek/models/ToolChoice;
 	public final fun getTools ()Ljava/util/List;
 	public final fun getTopLogprobs ()Ljava/lang/Integer;
@@ -525,6 +527,7 @@ public final class org/oremif/deepseek/models/ChatCompletionParams$Builder {
 	public final fun setResponseFormat (Lorg/oremif/deepseek/models/ResponseFormat;)V
 	public final fun setStop (Lorg/oremif/deepseek/models/StopReason;)V
 	public final fun setTemperature (Ljava/lang/Double;)V
+	public final fun setThinking (Lorg/oremif/deepseek/models/Thinking;)V
 	public final fun setToolChoice (Lorg/oremif/deepseek/models/ToolChoice;)V
 	public final fun setTools (Ljava/util/List;)V
 	public final fun setTopLogprobs (Ljava/lang/Integer;)V
@@ -542,6 +545,7 @@ public final class org/oremif/deepseek/models/ChatCompletionParams$StreamBuilder
 	public final fun getStop ()Lorg/oremif/deepseek/models/StopReason;
 	public final fun getStreamOptions ()Lorg/oremif/deepseek/models/StreamOptions;
 	public final fun getTemperature ()Ljava/lang/Double;
+	public final fun getThinking ()Lorg/oremif/deepseek/models/Thinking;
 	public final fun getToolChoice ()Lorg/oremif/deepseek/models/ToolChoice;
 	public final fun getTools ()Ljava/util/List;
 	public final fun getTopLogprobs ()Ljava/lang/Integer;
@@ -555,6 +559,7 @@ public final class org/oremif/deepseek/models/ChatCompletionParams$StreamBuilder
 	public final fun setStop (Lorg/oremif/deepseek/models/StopReason;)V
 	public final fun setStreamOptions (Lorg/oremif/deepseek/models/StreamOptions;)V
 	public final fun setTemperature (Ljava/lang/Double;)V
+	public final fun setThinking (Lorg/oremif/deepseek/models/Thinking;)V
 	public final fun setToolChoice (Lorg/oremif/deepseek/models/ToolChoice;)V
 	public final fun setTools (Ljava/util/List;)V
 	public final fun setTopLogprobs (Ljava/lang/Integer;)V
@@ -568,8 +573,8 @@ public final class org/oremif/deepseek/models/ChatCompletionParamsKt {
 
 public final class org/oremif/deepseek/models/ChatCompletionRequest {
 	public static final field Companion Lorg/oremif/deepseek/models/ChatCompletionRequest$Companion;
-	public fun <init> (Ljava/util/List;Lorg/oremif/deepseek/models/ChatModel;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Double;Lorg/oremif/deepseek/models/ResponseFormat;Lorg/oremif/deepseek/models/StopReason;Ljava/lang/Boolean;Lorg/oremif/deepseek/models/StreamOptions;Ljava/lang/Double;Ljava/lang/Double;Ljava/util/List;Lorg/oremif/deepseek/models/ToolChoice;Ljava/lang/Boolean;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Ljava/util/List;Lorg/oremif/deepseek/models/ChatModel;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Double;Lorg/oremif/deepseek/models/ResponseFormat;Lorg/oremif/deepseek/models/StopReason;Ljava/lang/Boolean;Lorg/oremif/deepseek/models/StreamOptions;Ljava/lang/Double;Ljava/lang/Double;Ljava/util/List;Lorg/oremif/deepseek/models/ToolChoice;Ljava/lang/Boolean;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lorg/oremif/deepseek/models/ChatModel;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Double;Lorg/oremif/deepseek/models/ResponseFormat;Lorg/oremif/deepseek/models/StopReason;Ljava/lang/Boolean;Lorg/oremif/deepseek/models/StreamOptions;Ljava/lang/Double;Ljava/lang/Double;Ljava/util/List;Lorg/oremif/deepseek/models/ToolChoice;Ljava/lang/Boolean;Ljava/lang/Integer;Lorg/oremif/deepseek/models/Thinking;)V
+	public synthetic fun <init> (Ljava/util/List;Lorg/oremif/deepseek/models/ChatModel;Ljava/lang/Double;Ljava/lang/Integer;Ljava/lang/Double;Lorg/oremif/deepseek/models/ResponseFormat;Lorg/oremif/deepseek/models/StopReason;Ljava/lang/Boolean;Lorg/oremif/deepseek/models/StreamOptions;Ljava/lang/Double;Ljava/lang/Double;Ljava/util/List;Lorg/oremif/deepseek/models/ToolChoice;Ljava/lang/Boolean;Ljava/lang/Integer;Lorg/oremif/deepseek/models/Thinking;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFrequencyPenalty ()Ljava/lang/Double;
 	public final fun getLogprobs ()Ljava/lang/Boolean;
@@ -582,6 +587,7 @@ public final class org/oremif/deepseek/models/ChatCompletionRequest {
 	public final fun getStream ()Ljava/lang/Boolean;
 	public final fun getStreamOptions ()Lorg/oremif/deepseek/models/StreamOptions;
 	public final fun getTemperature ()Ljava/lang/Double;
+	public final fun getThinking ()Lorg/oremif/deepseek/models/Thinking;
 	public final fun getToolChoice ()Lorg/oremif/deepseek/models/ToolChoice;
 	public final fun getTools ()Ljava/util/List;
 	public final fun getTopLogprobs ()Ljava/lang/Integer;
@@ -877,6 +883,7 @@ public final class org/oremif/deepseek/models/FIMCompletionRequest$StreamBuilder
 public final class org/oremif/deepseek/models/FIMLogProbs {
 	public static final field Companion Lorg/oremif/deepseek/models/FIMLogProbs$Companion;
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getTextOffset ()Ljava/util/List;
 	public final fun getTokenLogprobs ()Ljava/util/List;
@@ -1112,6 +1119,32 @@ public final class org/oremif/deepseek/models/ModelObjectType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class org/oremif/deepseek/models/PromptTokensDetails {
+	public static final field Companion Lorg/oremif/deepseek/models/PromptTokensDetails$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCachedTokens ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class org/oremif/deepseek/models/PromptTokensDetails$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/oremif/deepseek/models/PromptTokensDetails$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/oremif/deepseek/models/PromptTokensDetails;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/oremif/deepseek/models/PromptTokensDetails;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/oremif/deepseek/models/PromptTokensDetails$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class org/oremif/deepseek/models/ResponseFormat {
 	public static final field Companion Lorg/oremif/deepseek/models/ResponseFormat$Companion;
 	public fun equals (Ljava/lang/Object;)Z
@@ -1197,6 +1230,43 @@ public final synthetic class org/oremif/deepseek/models/SystemMessage$$serialize
 }
 
 public final class org/oremif/deepseek/models/SystemMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/oremif/deepseek/models/Thinking {
+	public static final field Companion Lorg/oremif/deepseek/models/Thinking$Companion;
+	public fun <init> (Lorg/oremif/deepseek/models/ThinkingType;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getType ()Lorg/oremif/deepseek/models/ThinkingType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class org/oremif/deepseek/models/Thinking$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/oremif/deepseek/models/Thinking$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/oremif/deepseek/models/Thinking;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/oremif/deepseek/models/Thinking;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/oremif/deepseek/models/Thinking$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/oremif/deepseek/models/ThinkingType : java/lang/Enum {
+	public static final field Companion Lorg/oremif/deepseek/models/ThinkingType$Companion;
+	public static final field DISABLED Lorg/oremif/deepseek/models/ThinkingType;
+	public static final field ENABLED Lorg/oremif/deepseek/models/ThinkingType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/oremif/deepseek/models/ThinkingType;
+	public static fun values ()[Lorg/oremif/deepseek/models/ThinkingType;
+}
+
+public final class org/oremif/deepseek/models/ThinkingType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1361,14 +1431,15 @@ public final class org/oremif/deepseek/models/TopLogProb$Companion {
 
 public final class org/oremif/deepseek/models/Usage {
 	public static final field Companion Lorg/oremif/deepseek/models/Usage$Companion;
-	public fun <init> (IILjava/lang/Integer;Ljava/lang/Integer;ILorg/oremif/deepseek/models/CompletionTokenDetails;)V
-	public synthetic fun <init> (IILjava/lang/Integer;Ljava/lang/Integer;ILorg/oremif/deepseek/models/CompletionTokenDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IILjava/lang/Integer;Ljava/lang/Integer;Lorg/oremif/deepseek/models/PromptTokensDetails;ILorg/oremif/deepseek/models/CompletionTokenDetails;)V
+	public synthetic fun <init> (IILjava/lang/Integer;Ljava/lang/Integer;Lorg/oremif/deepseek/models/PromptTokensDetails;ILorg/oremif/deepseek/models/CompletionTokenDetails;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCompletionTokens ()I
 	public final fun getCompletionTokensDetails ()Lorg/oremif/deepseek/models/CompletionTokenDetails;
 	public final fun getPromptCacheHitTokens ()Ljava/lang/Integer;
 	public final fun getPromptCacheMissTokens ()Ljava/lang/Integer;
 	public final fun getPromptTokens ()I
+	public final fun getPromptTokensDetails ()Lorg/oremif/deepseek/models/PromptTokensDetails;
 	public final fun getTotalTokens ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/ChatCompletionParams.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/ChatCompletionParams.kt
@@ -83,6 +83,7 @@ public fun chatCompletionStreamParams(block: ChatCompletionParams.StreamBuilder.
  * @property toolChoice Controls how the model selects tools to use
  * @property logprobs Whether to return log probabilities of output tokens
  * @property topLogprobs How many most likely tokens to return at each position (max 20)
+ * @property thinking Toggles the reasoning pass of `deepseek-reasoner`. See [Thinking].
  */
 public class ChatCompletionParams internal constructor(
     public val model: ChatModel,
@@ -99,6 +100,7 @@ public class ChatCompletionParams internal constructor(
     public val toolChoice: ToolChoice? = null,
     public val logprobs: Boolean? = null,
     public val topLogprobs: Int? = null,
+    public val thinking: Thinking? = null,
 ) : DeepSeekParams(frequencyPenalty, maxTokens, presencePenalty, stop, temperature, topP) {
 
     /**
@@ -117,6 +119,7 @@ public class ChatCompletionParams internal constructor(
         public var toolChoice: ToolChoice? = null
         public var logprobs: Boolean? = null
         public var topLogprobs: Int? = null
+        public var thinking: Thinking? = null
 
         internal fun build(): ChatCompletionParams {
             frequencyPenalty?.let { require(it in -2.0..2.0) { "frequencyPenalty must be between -2.0 and 2.0" } }
@@ -139,6 +142,7 @@ public class ChatCompletionParams internal constructor(
                 toolChoice = toolChoice,
                 logprobs = logprobs,
                 topLogprobs = topLogprobs,
+                thinking = thinking,
             )
         }
     }
@@ -160,6 +164,7 @@ public class ChatCompletionParams internal constructor(
         public var toolChoice: ToolChoice? = null
         public var logprobs: Boolean? = null
         public var topLogprobs: Int? = null
+        public var thinking: Thinking? = null
 
 
         internal fun build(): ChatCompletionParams {
@@ -185,6 +190,7 @@ public class ChatCompletionParams internal constructor(
                 toolChoice = toolChoice,
                 logprobs = logprobs,
                 topLogprobs = topLogprobs,
+                thinking = thinking,
             )
         }
     }
@@ -212,6 +218,7 @@ public class ChatCompletionParams internal constructor(
             toolChoice = toolChoice,
             logprobs = logprobs,
             topLogprobs = topLogprobs,
+            thinking = thinking,
         )
 
     /**
@@ -237,6 +244,7 @@ public class ChatCompletionParams internal constructor(
      * @param toolChoice New tool choice, or existing value if not specified
      * @param logprobs New log probabilities setting, or existing value if not specified
      * @param topLogprobs New top log probabilities count, or existing value if not specified
+     * @param thinking New thinking-mode toggle, or existing value if not specified
      * @return A new [ChatCompletionParams] instance with the specified changes
      */
     public fun copy(
@@ -254,6 +262,7 @@ public class ChatCompletionParams internal constructor(
         toolChoice: ToolChoice? = this.toolChoice,
         logprobs: Boolean? = this.logprobs,
         topLogprobs: Int? = this.topLogprobs,
+        thinking: Thinking? = this.thinking,
     ): ChatCompletionParams {
         return ChatCompletionParams(
             model = model,
@@ -270,6 +279,7 @@ public class ChatCompletionParams internal constructor(
             toolChoice = toolChoice,
             logprobs = logprobs,
             topLogprobs = topLogprobs,
+            thinking = thinking,
         )
     }
 
@@ -291,7 +301,8 @@ public class ChatCompletionParams internal constructor(
                 tools == other.tools &&
                 toolChoice == other.toolChoice &&
                 logprobs == other.logprobs &&
-                topLogprobs == other.topLogprobs
+                topLogprobs == other.topLogprobs &&
+                thinking == other.thinking
     }
 
     override fun hashCode(): Int {
@@ -309,10 +320,11 @@ public class ChatCompletionParams internal constructor(
         result = 31 * result + (streamOptions?.hashCode() ?: 0)
         result = 31 * result + (tools?.hashCode() ?: 0)
         result = 31 * result + (toolChoice?.hashCode() ?: 0)
+        result = 31 * result + (thinking?.hashCode() ?: 0)
         return result
     }
 
     override fun toString(): String {
-        return "ChatCompletionParams(model=$model, frequencyPenalty=$frequencyPenalty, maxTokens=$maxTokens, presencePenalty=$presencePenalty, responseFormat=$responseFormat, stop=$stop, stream=$stream, streamOptions=$streamOptions, temperature=$temperature, topP=$topP, tools=$tools, toolChoice=$toolChoice, logprobs=$logprobs, topLogprobs=$topLogprobs)"
+        return "ChatCompletionParams(model=$model, frequencyPenalty=$frequencyPenalty, maxTokens=$maxTokens, presencePenalty=$presencePenalty, responseFormat=$responseFormat, stop=$stop, stream=$stream, streamOptions=$streamOptions, temperature=$temperature, topP=$topP, tools=$tools, toolChoice=$toolChoice, logprobs=$logprobs, topLogprobs=$topLogprobs, thinking=$thinking)"
     }
 }

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/ChatCompletionRequest.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/ChatCompletionRequest.kt
@@ -78,6 +78,9 @@ import kotlinx.serialization.Serializable
  * position, each with an associated log probability. `logprobs` must be set to `true` if this parameter is used.
  *
  * **Possible values: `<= 20`.**
+ * @property thinking Toggles the reasoning pass of the `deepseek-reasoner` model. See
+ * [Thinking] for the server-side behaviour, in particular the model-slug rewrite that
+ * happens when [ThinkingType.DISABLED] is sent with `model = deepseek-reasoner`.
  */
 @Serializable
 public class ChatCompletionRequest(
@@ -96,6 +99,7 @@ public class ChatCompletionRequest(
     public val toolChoice: ToolChoice? = null,
     public val logprobs: Boolean? = null,
     public val topLogprobs: Int? = null,
+    public val thinking: Thinking? = null,
 ) {
 
     /**
@@ -247,7 +251,8 @@ public class ChatCompletionRequest(
                 tools == other.tools &&
                 toolChoice == other.toolChoice &&
                 logprobs == other.logprobs &&
-                topLogprobs == other.topLogprobs
+                topLogprobs == other.topLogprobs &&
+                thinking == other.thinking
     }
 
     override fun hashCode(): Int {
@@ -266,9 +271,10 @@ public class ChatCompletionRequest(
         result = 31 * result + (toolChoice?.hashCode() ?: 0)
         result = 31 * result + (logprobs?.hashCode() ?: 0)
         result = 31 * result + (topLogprobs?.hashCode() ?: 0)
+        result = 31 * result + (thinking?.hashCode() ?: 0)
         return result
     }
 
     override fun toString(): String =
-        "ChatCompletionRequest(messages=$messages, model=$model, frequencyPenalty=$frequencyPenalty, maxTokens=$maxTokens, presencePenalty=$presencePenalty, responseFormat=$responseFormat, stop=$stop, stream=$stream, streamOptions=$streamOptions, temperature=$temperature, topP=$topP, tools=$tools, toolChoice=$toolChoice, logprobs=$logprobs, topLogprobs=$topLogprobs)"
+        "ChatCompletionRequest(messages=$messages, model=$model, frequencyPenalty=$frequencyPenalty, maxTokens=$maxTokens, presencePenalty=$presencePenalty, responseFormat=$responseFormat, stop=$stop, stream=$stream, streamOptions=$streamOptions, temperature=$temperature, topP=$topP, tools=$tools, toolChoice=$toolChoice, logprobs=$logprobs, topLogprobs=$topLogprobs, thinking=$thinking)"
 }

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/Logprobs.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/Logprobs.kt
@@ -105,15 +105,20 @@ public class TopLogProb(
  * @property textOffset Character offset of each token into the generated text.
  * @property tokenLogprobs Natural-log probability of each token in [tokens].
  * @property tokens The generated tokens as text.
- * @property topLogprobs For each token position, the alternatives considered, or `null`
- * when the request did not ask for top-logprobs.
+ * @property topLogprobs For each generated token position, a map from candidate token
+ * text to its natural-log probability. Populated only when the request sets
+ * `logprobs > 0`; `null` otherwise. Candidates that were considered but scored out of
+ * range typically appear with a sentinel value of `-9999.0`.
+ *
+ * Note: this shape is specific to the legacy completions endpoint and differs from
+ * chat's [LogProb.topLogprobs], which is a list of [TopLogProb] objects.
  */
 @Serializable
 public class FIMLogProbs(
     public val textOffset: List<Int>,
     public val tokenLogprobs: List<Double>,
     public val tokens: List<String>,
-    public val topLogprobs: List<TopLogProb>?
+    public val topLogprobs: List<Map<String, Double>>? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/PromptTokensDetails.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/PromptTokensDetails.kt
@@ -1,0 +1,30 @@
+package org.oremif.deepseek.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Breakdown of the prompt tokens counted by [Usage], returned by the API under the
+ * `prompt_tokens_details` key.
+ *
+ * Distinct from the older flat fields [Usage.promptCacheHitTokens] /
+ * [Usage.promptCacheMissTokens]: both shapes may appear in the same response, and
+ * either may be `null` depending on the model and the API version that served the
+ * request.
+ *
+ * @property cachedTokens Number of prompt tokens served from the context cache, or
+ * `null` when the server did not report this breakdown.
+ */
+@Serializable
+public class PromptTokensDetails(
+    public val cachedTokens: Int? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PromptTokensDetails) return false
+        return cachedTokens == other.cachedTokens
+    }
+
+    override fun hashCode(): Int = cachedTokens?.hashCode() ?: 0
+
+    override fun toString(): String = "PromptTokensDetails(cachedTokens=$cachedTokens)"
+}

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/Thinking.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/Thinking.kt
@@ -1,0 +1,57 @@
+package org.oremif.deepseek.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Toggles the reasoning ("thinking") pass of the `deepseek-reasoner` model.
+ *
+ * When omitted, `deepseek-reasoner` behaves as if [ThinkingType.ENABLED] were passed.
+ *
+ * Important behaviour observed against the live API: sending
+ * `Thinking(ThinkingType.DISABLED)` together with `model = [ChatModel.DEEPSEEK_REASONER]`
+ * causes the server to route the request to `deepseek-chat`. The returned
+ * [ChatCompletion.model] comes back as `"deepseek-chat"` and no `reasoning_content` is
+ * produced. Consumers that branch on `response.model` must account for this rewrite.
+ *
+ * Example:
+ * ```kotlin
+ * val params = chatCompletionParams {
+ *     model = ChatModel.DEEPSEEK_REASONER
+ *     thinking = Thinking(ThinkingType.DISABLED) // server routes to deepseek-chat
+ * }
+ * ```
+ *
+ * @property type Whether the reasoning pass runs for this request.
+ */
+@Serializable
+public class Thinking(
+    public val type: ThinkingType,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Thinking) return false
+        return type == other.type
+    }
+
+    override fun hashCode(): Int = type.hashCode()
+
+    override fun toString(): String = "Thinking(type=$type)"
+}
+
+/**
+ * Values accepted by [Thinking.type].
+ */
+@Serializable
+public enum class ThinkingType {
+    /** Reasoning pass is active (default behaviour of `deepseek-reasoner`). */
+    @SerialName("enabled")
+    ENABLED,
+
+    /**
+     * Reasoning pass is suppressed. Paired with `model = deepseek-reasoner`, the server
+     * transparently downgrades the request to `deepseek-chat` — see [Thinking].
+     */
+    @SerialName("disabled")
+    DISABLED,
+}

--- a/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/Usage.kt
+++ b/deepseek-kotlin/src/commonMain/kotlin/org/oremif/deepseek/models/Usage.kt
@@ -14,9 +14,13 @@ import kotlinx.serialization.Serializable
  * @property promptTokens Number of tokens in the prompt. When context caching applies,
  * this equals [promptCacheHitTokens] + [promptCacheMissTokens].
  * @property promptCacheHitTokens Number of prompt tokens served from the context cache,
- * or `null` when caching does not apply.
+ * or `null` when caching does not apply. Legacy field; newer responses may report the
+ * same information under [promptTokensDetails] instead.
  * @property promptCacheMissTokens Number of prompt tokens not served from the context
- * cache, or `null` when caching does not apply.
+ * cache, or `null` when caching does not apply. Legacy field; see [promptTokensDetails].
+ * @property promptTokensDetails Structured breakdown of [promptTokens] under the
+ * `prompt_tokens_details` key, matching the OpenAI-compatible shape. May be `null`
+ * for older API versions.
  * @property totalTokens Total tokens billed for the request (prompt + completion).
  * @property completionTokensDetails Breakdown of how [completionTokens] was spent (e.g.
  * reasoning tokens for `deepseek-reasoner`).
@@ -27,6 +31,7 @@ public class Usage(
     public val promptTokens: Int,
     public val promptCacheHitTokens: Int? = null,
     public val promptCacheMissTokens: Int? = null,
+    public val promptTokensDetails: PromptTokensDetails? = null,
     public val totalTokens: Int,
     public val completionTokensDetails: CompletionTokenDetails? = null,
 ) {
@@ -37,6 +42,7 @@ public class Usage(
                 promptTokens == other.promptTokens &&
                 promptCacheHitTokens == other.promptCacheHitTokens &&
                 promptCacheMissTokens == other.promptCacheMissTokens &&
+                promptTokensDetails == other.promptTokensDetails &&
                 totalTokens == other.totalTokens &&
                 completionTokensDetails == other.completionTokensDetails
     }
@@ -46,11 +52,12 @@ public class Usage(
         result = 31 * result + promptTokens.hashCode()
         result = 31 * result + (promptCacheHitTokens ?: 0)
         result = 31 * result + (promptCacheMissTokens ?: 0)
+        result = 31 * result + (promptTokensDetails?.hashCode() ?: 0)
         result = 31 * result + totalTokens.hashCode()
         result = 31 * result + (completionTokensDetails?.hashCode() ?: 0)
         return result
     }
 
     override fun toString(): String =
-        "Usage(completionTokens=$completionTokens, promptTokens=$promptTokens, promptCacheHitTokens=$promptCacheHitTokens, promptCacheMissTokens=$promptCacheMissTokens, totalTokens=$totalTokens, completionTokensDetails=$completionTokensDetails)"
+        "Usage(completionTokens=$completionTokens, promptTokens=$promptTokens, promptCacheHitTokens=$promptCacheHitTokens, promptCacheMissTokens=$promptCacheMissTokens, promptTokensDetails=$promptTokensDetails, totalTokens=$totalTokens, completionTokensDetails=$completionTokensDetails)"
 }


### PR DESCRIPTION
## Summary

Three wire-format corrections uncovered while running the SDK against the live DeepSeek API:

- **Add `thinking: Thinking?`** on `ChatCompletionRequest` / `ChatCompletionParams` (+ Builder / StreamBuilder / `createRequest` / `copy` / equals / hashCode / toString). New `Thinking(type: ThinkingType)` with `ThinkingType { ENABLED, DISABLED }`. KDoc notes the server behaviour: `ThinkingType.DISABLED` with `model = deepseek-reasoner` causes the server to transparently route the request to `deepseek-chat` (response `model` field flips to `"deepseek-chat"`, no `reasoning_content` produced).
- **Add `promptTokensDetails: PromptTokensDetails?`** on `Usage`. The live API returns `"usage": { "prompt_tokens_details": { "cached_tokens": N } }` on every chat / reasoner / FIM response; the SDK was silently dropping it. The legacy flat `promptCacheHitTokens` / `promptCacheMissTokens` fields are kept for compatibility — both shapes currently arrive in the same response.
- **Fix `FIMLogProbs.topLogprobs` type** from `List<TopLogProb>?` to `List<Map<String, Double>>?`. The legacy completions endpoint returns per-position maps of candidate-token → logprob, not the chat-shaped `TopLogProb(token, logprob, bytes)`. With the old type, any FIM request with `logprobs > 0` threw `MissingFieldException: Fields [token, logprob, bytes] are required for 'TopLogProb'`.

ABI dumps regenerated (`apiDump`). `FIMLogProbs.topLogprobs` type change and the new `Usage` constructor parameter are binary-breaking, but the old FIM shape was crashing at runtime, and `Usage` is only constructed via named parameters inside the SDK.

## Test plan

- [x] `./gradlew :deepseek-kotlin:jvmTest` (offline packages) — green
- [x] `./gradlew :deepseek-kotlin:apiCheck` — green after `apiDump`
- [x] Live integration smoke-tests against `https://api.deepseek.com` on a throwaway branch:
  - `chatBasic`, `chatReasoner`, `chatStreamingWithUsage` — `Usage.promptTokensDetails` populated on all three
  - FIM with `logprobs = 5` — SDK now parses `topLogprobs` as `List<Map<String, Double>>` (previously threw `MissingFieldException`)
  - Raw POST with `thinking: { type: "enabled" | "disabled" }` — server accepts both; `"disabled"` on reasoner rewrites response `model` to `"deepseek-chat"` as documented in `Thinking` KDoc
  - `Authorization: Bearer <token>` emitted cleanly by the Ktor `Auth` plugin — no side effects from the empty refresh token