### PR TITLE
docs: point Maven Central badge to Central Portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DeepSeek Kotlin SDK
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.oremif/deepseek-kotlin)](https://search.maven.org/artifact/org.oremif/deepseek-kotlin)
+[![Maven Central](https://img.shields.io/maven-central/v/org.oremif/deepseek-kotlin)](https://central.sonatype.com/artifact/org.oremif/deepseek-kotlin)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Kotlin](https://img.shields.io/badge/kotlin-multiplatform-blue.svg?logo=kotlin)](https://kotlinlang.org)
 [![CI](https://github.com/Oremif/deepseek-kotlin/actions/workflows/ci.yml/badge.svg)](https://github.com/Oremif/deepseek-kotlin/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary
- The Maven Central badge linked to `search.maven.org`, which now redirects to a generic Sonatype landing page instead of the artifact.
- Point the badge at `central.sonatype.com/artifact/org.oremif/deepseek-kotlin` so clicking it lands on the actual artifact page (matches the convention used in the `kstats` repo).

## Test plan
- [x] Confirm the rendered badge target resolves to the DeepSeek Kotlin artifact on Central Portal.